### PR TITLE
Fix error in comparing intended tag and current tag in federated execution.

### DIFF
--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -1,0 +1,113 @@
+import {Action, FederatePortAction, App, Origin, TimeValue, Triggers, Args, Tag} from '../src/core/internal';
+
+let intendedTagDelay: TimeValue | undefined
+let intendedTagMicrostepDelay: number
+let startUpTag: Tag
+
+class ReactorWithFederatePortAction extends App {
+    a = new Action<number>(this, Origin.logical, TimeValue.nsec(10))
+    f = new FederatePortAction<number>(this, Origin.logical)
+    
+    constructor () {
+        super(TimeValue.msec(1));
+        this.addReaction(
+            new Triggers(this.startup),
+            new Args(this.schedulable(this.a)),
+            function(this, a){
+                startUpTag = this.util.getCurrentTag()
+                a.schedule(0, 0);
+            }
+        );
+
+        this.addReaction(
+            new Triggers(this.a),
+            new Args(this.schedulable(this.f)),
+            function(this, f){
+                let intendedTag: Tag | undefined
+                if (intendedTagDelay === undefined) {
+                    intendedTag = undefined
+                } else {
+                    intendedTag = startUpTag.getLaterTag(intendedTagDelay).getMicroStepsLater(intendedTagMicrostepDelay)
+                }
+                f.schedule(0, 0, intendedTag);
+            }
+        );
+    }
+
+    public setLastTagProvisional(value: boolean) {
+        this._isLastTAGProvisional = value
+    }
+}
+
+describe('Intended tag tests', function () {
+    it('Undefined inteded tag', function() {
+        intendedTagDelay = undefined
+        let app = new ReactorWithFederatePortAction()
+        expect(() => app._start()).toThrowError("FederatedPortAction must have an intended tag from RTI.")
+    })
+    
+    it('Intended tag smaller than current tag', function() {
+        intendedTagDelay = TimeValue.nsec(9)
+        intendedTagMicrostepDelay = 0
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(false)
+        expect(() => app._start()).toThrowError("Intended tag must be greater than current tag. Intended tag")
+    })
+    
+    it('Intended tag equal to current tag', function() {
+        intendedTagDelay = TimeValue.nsec(10)
+        intendedTagMicrostepDelay = 1
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(false)
+        expect(() => app._start()).toThrowError("Intended tag must be greater than current tag. Intended tag")
+    })
+    
+    it('Intended tag greater than current tag', function() {
+        intendedTagDelay = TimeValue.nsec(11)
+        intendedTagMicrostepDelay = 0
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(false)
+        app._start()
+    })
+
+    it('Intended tag greater than current tag by microstep', function() {
+        intendedTagDelay = TimeValue.nsec(10)
+        intendedTagMicrostepDelay = 2
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(false)
+        app._start()
+    })
+})
+
+describe('Intended tag tests when TAG is provisional', function () {
+    it('Intended tag smaller than current tag', function() {
+        intendedTagDelay = TimeValue.nsec(9)
+        intendedTagMicrostepDelay = 0
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(true)
+        expect(() => app._start()).toThrowError("Intended tag must be greater than or equal to current tag.when the last tag is provisional Intended tag")
+    })
+    
+    it('Intended tag equal to current tag', function() {
+        intendedTagDelay = TimeValue.nsec(10)
+        intendedTagMicrostepDelay = 1
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(true)
+    })
+    
+    it('Intended tag greater than current tag', function() {
+        intendedTagDelay = TimeValue.nsec(11)
+        intendedTagMicrostepDelay = 0
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(true)
+        app._start()
+    })
+
+    it('Intended tag greater than current tag by microstep', function() {
+        intendedTagDelay = TimeValue.nsec(10)
+        intendedTagMicrostepDelay = 2
+        let app = new ReactorWithFederatePortAction()
+        app.setLastTagProvisional(true)
+        app._start()
+    })
+})

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -59,7 +59,7 @@ describe('Intended tag tests', function () {
         intendedTagMicrostepDelay = 1
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(false)
-        expect(() => app._start()).toThrowError("Intended tag must be greater than current tag. Intended tag")
+        expect(() => app._start()).toThrowError("Intended tag must be greater than current tag. Intended tag: ")
     })
     
     it('Intended tag greater than current tag', function() {
@@ -85,7 +85,7 @@ describe('Intended tag tests when TAG is provisional', function () {
         intendedTagMicrostepDelay = 0
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(true)
-        expect(() => app._start()).toThrowError("Intended tag must be greater than or equal to current tag.when the last tag is provisional Intended tag")
+        expect(() => app._start()).toThrowError("Intended tag must be greater than or equal to current tag, when the last TAG is provisional. Intended tag: ")
     })
     
     it('Intended tag equal to current tag', function() {

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -67,7 +67,7 @@ describe('Intended tag tests', function () {
         intendedTagMicrostepDelay = 0
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(false)
-        app._start()
+        expect(() => app._start()).not.toThrow()
     })
 
     it('Intended tag greater than current tag by microstep', function() {
@@ -75,7 +75,7 @@ describe('Intended tag tests', function () {
         intendedTagMicrostepDelay = 2
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(false)
-        app._start()
+        expect(() => app._start()).not.toThrow()
     })
 })
 
@@ -93,6 +93,7 @@ describe('Intended tag tests when TAG is provisional', function () {
         intendedTagMicrostepDelay = 1
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(true)
+        expect(() => app._start()).not.toThrow()
     })
     
     it('Intended tag greater than current tag', function() {
@@ -100,7 +101,7 @@ describe('Intended tag tests when TAG is provisional', function () {
         intendedTagMicrostepDelay = 0
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(true)
-        app._start()
+        expect(() => app._start()).not.toThrow()
     })
 
     it('Intended tag greater than current tag by microstep', function() {
@@ -108,6 +109,6 @@ describe('Intended tag tests when TAG is provisional', function () {
         intendedTagMicrostepDelay = 2
         let app = new ReactorWithFederatePortAction()
         app.setLastTagProvisional(true)
-        app._start()
+        expect(() => app._start()).not.toThrow()
     })
 })

--- a/__tests__/time.test.ts
+++ b/__tests__/time.test.ts
@@ -180,6 +180,7 @@ describe('time helper functions', function () {
      * Microstep indices are taken into consideration.
      */
     it('compare tags', function () {
+        // isSmallerThan
         expect(tiZero.isSmallerThan(tiZero)).toBeFalsy();
         expect(tiZero.isSmallerThan(tiZero1)).toBeTruthy();
         expect(tiZero1.isSmallerThan(tiZero)).toBeFalsy();
@@ -198,6 +199,26 @@ describe('time helper functions', function () {
         expect(tiFiveSeconds0.isSmallerThan(tiZero1)).toBeFalsy();
         expect(tiFiveSeconds1.isSmallerThan(tiZero1)).toBeFalsy();
 
+        // isSmallerThanOrEqualTo
+        expect(tiZero.isSmallerThanOrEqualTo(tiZero)).toBeTruthy();
+        expect(tiZero.isSmallerThanOrEqualTo(tiZero1)).toBeTruthy();
+        expect(tiZero1.isSmallerThanOrEqualTo(tiZero)).toBeFalsy();
+
+        expect(tiFiveSeconds0.isSmallerThanOrEqualTo(tiFiveSeconds0)).toBeTruthy();
+        expect(tiFiveSeconds0.isSmallerThanOrEqualTo(tiFiveSeconds1)).toBeTruthy();
+        expect(tiFiveSeconds1.isSmallerThanOrEqualTo(tiFiveSeconds0)).toBeFalsy();
+
+        expect(tiZero.isSmallerThanOrEqualTo(tiFiveSeconds0)).toBeTruthy();
+        expect(tiZero.isSmallerThanOrEqualTo(tiFiveSeconds1)).toBeTruthy();
+        expect(tiZero1.isSmallerThanOrEqualTo(tiFiveSeconds0)).toBeTruthy();
+        expect(tiZero1.isSmallerThanOrEqualTo(tiFiveSeconds1)).toBeTruthy();
+        
+        expect(tiFiveSeconds0.isSmallerThanOrEqualTo(tiZero)).toBeFalsy();
+        expect(tiFiveSeconds1.isSmallerThanOrEqualTo(tiZero)).toBeFalsy();
+        expect(tiFiveSeconds0.isSmallerThanOrEqualTo(tiZero1)).toBeFalsy();
+        expect(tiFiveSeconds1.isSmallerThanOrEqualTo(tiZero1)).toBeFalsy();
+
+        // isGreaterThan
         expect(tiZero.isGreaterThan(tiZero)).toBeFalsy();
         expect(tiZero.isGreaterThan(tiZero1)).toBeFalsy();
         expect(tiZero1.isGreaterThan(tiZero)).toBeTruthy();
@@ -216,6 +237,24 @@ describe('time helper functions', function () {
         expect(tiFiveSeconds0.isGreaterThan(tiZero1)).toBeTruthy();
         expect(tiFiveSeconds1.isGreaterThan(tiZero1)).toBeTruthy();
 
+        // isGreaterThanOrEqualTo
+        expect(tiZero.isGreaterThanOrEqualTo(tiZero)).toBeTruthy();
+        expect(tiZero.isGreaterThanOrEqualTo(tiZero1)).toBeFalsy();
+        expect(tiZero1.isGreaterThanOrEqualTo(tiZero)).toBeTruthy();
+
+        expect(tiFiveSeconds0.isGreaterThanOrEqualTo(tiFiveSeconds0)).toBeTruthy();
+        expect(tiFiveSeconds0.isGreaterThanOrEqualTo(tiFiveSeconds1)).toBeFalsy();
+        expect(tiFiveSeconds1.isGreaterThan(tiFiveSeconds0)).toBeTruthy();
+
+        expect(tiZero.isGreaterThanOrEqualTo(tiFiveSeconds0)).toBeFalsy();
+        expect(tiZero.isGreaterThanOrEqualTo(tiFiveSeconds1)).toBeFalsy();
+        expect(tiZero1.isGreaterThanOrEqualTo(tiFiveSeconds0)).toBeFalsy();
+        expect(tiZero1.isGreaterThanOrEqualTo(tiFiveSeconds1)).toBeFalsy();
+        
+        expect(tiFiveSeconds0.isGreaterThanOrEqualTo(tiZero)).toBeTruthy();
+        expect(tiFiveSeconds1.isGreaterThanOrEqualTo(tiZero)).toBeTruthy();
+        expect(tiFiveSeconds0.isGreaterThanOrEqualTo(tiZero1)).toBeTruthy();
+        expect(tiFiveSeconds1.isGreaterThanOrEqualTo(tiZero1)).toBeTruthy();
     });
 
     /**

--- a/__tests__/time.test.ts
+++ b/__tests__/time.test.ts
@@ -273,7 +273,11 @@ describe('time helper functions', function () {
      * Compare two time values and find out which one is earlier.
      */
     it('compare time values', function() {
+        expect(TimeValue.secsAndNs(10, 10).isEarlierThan(TimeValue.secsAndNs(11, 1))).toEqual(true)
         expect(TimeValue.secsAndNs(0, 999999998).isEarlierThan(TimeValue.secsAndNs(0, 999999999))).toEqual(true)
+
+        expect(TimeValue.secsAndNs(0, 999999999).isLaterThan(TimeValue.secsAndNs(0, 999999998))).toEqual(true)
+        expect(TimeValue.secsAndNs(11, 1).isLaterThan(TimeValue.secsAndNs(10, 10))).toEqual(true)
     });
 
 

--- a/__tests__/time.test.ts
+++ b/__tests__/time.test.ts
@@ -198,6 +198,24 @@ describe('time helper functions', function () {
         expect(tiFiveSeconds0.isSmallerThan(tiZero1)).toBeFalsy();
         expect(tiFiveSeconds1.isSmallerThan(tiZero1)).toBeFalsy();
 
+        expect(tiZero.isGreaterThan(tiZero)).toBeFalsy();
+        expect(tiZero.isGreaterThan(tiZero1)).toBeFalsy();
+        expect(tiZero1.isGreaterThan(tiZero)).toBeTruthy();
+
+        expect(tiFiveSeconds0.isGreaterThan(tiFiveSeconds0)).toBeFalsy();
+        expect(tiFiveSeconds0.isGreaterThan(tiFiveSeconds1)).toBeFalsy();
+        expect(tiFiveSeconds1.isGreaterThan(tiFiveSeconds0)).toBeTruthy();
+
+        expect(tiZero.isGreaterThan(tiFiveSeconds0)).toBeFalsy();
+        expect(tiZero.isGreaterThan(tiFiveSeconds1)).toBeFalsy();
+        expect(tiZero1.isGreaterThan(tiFiveSeconds0)).toBeFalsy();
+        expect(tiZero1.isGreaterThan(tiFiveSeconds1)).toBeFalsy();
+        
+        expect(tiFiveSeconds0.isGreaterThan(tiZero)).toBeTruthy();
+        expect(tiFiveSeconds1.isGreaterThan(tiZero)).toBeTruthy();
+        expect(tiFiveSeconds0.isGreaterThan(tiZero1)).toBeTruthy();
+        expect(tiFiveSeconds1.isGreaterThan(tiZero1)).toBeTruthy();
+
     });
 
     /**

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -82,11 +82,11 @@ export abstract class SchedulableAction<T extends Present> implements Sched<T> {
                 if (intendedTag === undefined) {
                     throw new Error("FederatedPortAction must have an intended tag from RTI.");
                 }
-                if (!this.action.runtime.util.isLastTAGProvisional() && intendedTag <= this.action.runtime.util.getCurrentTag()) {
+                if (!this.action.runtime.util.isLastTAGProvisional() && !intendedTag.isGreaterThan(this.action.runtime.util.getCurrentTag())) {
                     throw new Error("Intended tag must be greater than current tag. Intended tag" +
                         intendedTag + " Current tag: " + this.action.runtime.util.getCurrentTag());
                 }
-                if (this.action.runtime.util.isLastTAGProvisional() && intendedTag < this.action.runtime.util.getCurrentTag()) {
+                if (this.action.runtime.util.isLastTAGProvisional() && !intendedTag.isGreaterThanOrEqualTo(this.action.runtime.util.getCurrentTag())) {
                     throw new Error("Intended tag must be greater than or equal to current tag." +
                         "when the last tag is provisional Intended tag" + intendedTag +
                         " Current tag: " + this.action.runtime.util.getCurrentTag());

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -83,12 +83,12 @@ export abstract class SchedulableAction<T extends Present> implements Sched<T> {
                     throw new Error("FederatedPortAction must have an intended tag from RTI.");
                 }
                 if (!this.action.runtime.util.isLastTAGProvisional() && !intendedTag.isGreaterThan(this.action.runtime.util.getCurrentTag())) {
-                    throw new Error("Intended tag must be greater than current tag. Intended tag" +
+                    throw new Error("Intended tag must be greater than current tag. Intended tag: " +
                         intendedTag + " Current tag: " + this.action.runtime.util.getCurrentTag());
                 }
                 if (this.action.runtime.util.isLastTAGProvisional() && !intendedTag.isGreaterThanOrEqualTo(this.action.runtime.util.getCurrentTag())) {
-                    throw new Error("Intended tag must be greater than or equal to current tag." +
-                        "when the last tag is provisional Intended tag" + intendedTag +
+                    throw new Error("Intended tag must be greater than or equal to current tag" +
+                        ", when the last TAG is provisional. Intended tag: " + intendedTag +
                         " Current tag: " + this.action.runtime.util.getCurrentTag());
                 }
                 Log.debug(this, () => "Using intended tag from RTI, similar to schedule_at_tag(tag) with an intended tag: " +

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -395,6 +395,14 @@ export class Tag {
     }
 
     /**
+     * Return `true` if the tag is smaller than or equal to the tag given as a parameter.
+     * @param other The time instant to compare against this one.
+     */
+    isSmallerThanOrEqualTo(other: Tag): boolean {
+        return !this.isGreaterThan(other)
+    }
+
+    /**
      * Return `true` if the tag is greater than the tag given as a parameter.
      * @param other The time instant to compare against this one.
      */
@@ -402,6 +410,14 @@ export class Tag {
         return this.time.isLaterThan(other.time) 
             || (this.time.isEqualTo(other.time) 
                 && this.microstep > other.microstep);
+    }
+
+    /**
+     * Return `true` if the tag is greater than or equal to the tag given as a parameter.
+     * @param other The time instant to compare against this one.
+     */
+    isGreaterThanOrEqualTo(other: Tag): boolean {
+        return !this.isSmallerThan(other)
     }
 
     /**

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -197,6 +197,20 @@ export class TimeValue {
         }
         return false;
     }
+    /**
+     * Return true if this time value is later than the time given as a parameter.
+     * 
+     * @param other The time value to compare to this one.
+     */
+    isLaterThan(other: TimeValue) {
+        if (this.seconds > other.seconds) {
+            return true;
+        }
+        if (this.seconds == other.seconds && this.nanoseconds > other.nanoseconds) {
+            return true;
+        }
+        return false;
+    }
 
     /**
      * Return a millisecond representation of this time value.
@@ -385,9 +399,9 @@ export class Tag {
      * @param other The time instant to compare against this one.
      */
     isGreaterThan(other: Tag): boolean {
-        return other.time.isEarlierThan(this.time) 
-            || (other.time.isEqualTo(this.time) 
-                && other.microstep < this.microstep);
+        return this.time.isLaterThan(other.time) 
+            || (this.time.isEqualTo(other.time) 
+                && this.microstep > other.microstep);
     }
 
     /**

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -381,6 +381,16 @@ export class Tag {
     }
 
     /**
+     * Return `true` if the tag is greater than the tag given as a parameter.
+     * @param other The time instant to compare against this one.
+     */
+    isGreaterThan(other: Tag): boolean {
+        return other.time.isEarlierThan(this.time) 
+            || (other.time.isEqualTo(this.time) 
+                && other.microstep < this.microstep);
+    }
+
+    /**
      * Return `true` if this tag is simultaneous with the tag given as
      * a parameter, false otherwise. Both `time` and `microstep` must be equal
      * for two tags to be simultaneous.


### PR DESCRIPTION
This error was discovered while testing the TypeScript chat application in https://github.com/lf-lang/examples-lingua-franca/pull/10/.

I also added unit tests so that we can avoid error in the future.

I found that the operators like <, <= do not work correctly in the generated .js code.

Raw error messages:
```
/Users/hokeunkim/Development/examples-lingua-franca/TypeScript/src-gen/ChatApplication/SimpleChat/dist/core/action.js:112
            throw new Error("Intended tag must be greater than current tag. Intended tag" + intendedTag + " Current tag: " + this.action.runtime.util.getCurrentTag());
            ^

Error: Intended tag must be greater than current tag. Intended tag((1659547361 secs; 115322112 nsecs), 1) Current tag: ((1659547361 secs; 45592064 nsecs), 0)
    at Object.schedule (/Users/hokeunkim/Development/examples-lingua-franca/TypeScript/src-gen/ChatApplication/SimpleChat/dist/core/action.js:112:19)
    at RTIClient.<anonymous> (/Users/hokeunkim/Development/examples-lingua-franca/TypeScript/src-gen/ChatApplication/SimpleChat/dist/core/federation.js:1319:68)
    at RTIClient.emit (node:events:526:28)
    at RTIClient.handleSocketData (/Users/hokeunkim/Development/examples-lingua-franca/TypeScript/src-gen/ChatApplication/SimpleChat/dist/core/federation.js:698:22)
    at Socket.emit (node:events:526:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
```

This also increases test coverage for action.ts (68.63% -> 86.27%):

Before:
![Screen Shot 2022-08-03 at 10 46 57 AM](https://user-images.githubusercontent.com/2585943/182675168-2e8376e1-422b-4e59-95be-16d5ebff4dac.png)

After:
![Screen Shot 2022-08-03 at 10 46 32 AM](https://user-images.githubusercontent.com/2585943/182675152-60d0962c-43b2-4bbb-8a09-3fb709e95e56.png)

