### PR TITLE
Fix errors with reaction orders.

### DIFF
--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2062,9 +2062,6 @@ export class App extends Reactor {
                     // Look at the next event on the queue.
                     nextEvent = this._eventQ.peek();
                 }
-
-                // React to all the events loaded onto the reaction queue.
-                this._react()
                 
                 // End of this execution step. Perform cleanup.
                 while (this._reactorsToRemove.length > 0) {
@@ -2080,6 +2077,9 @@ export class App extends Reactor {
                 nextEvent = this._eventQ.peek();
 
             } while (nextEvent && this._currentTag.time.isEqualTo(nextEvent.tag.time));
+
+            // React to all the events loaded onto the reaction queue.
+            this._react()
 
             // Done handling events.
             // _iterationComplete() sends a LTC (Logical Tag Complete) message when federated.


### PR DESCRIPTION
Fix errors with reaction orders by making sure that all events at the certain tag are collected before executing reactions. (Previously, reactions were executed even when there are other events at the same tag were not collected.)

This was discovered while working on port absent messages with @ByeongGil-Jun.

Here is how to replicate the error:

C target LF program:
https://github.com/lf-lang/examples-lingua-franca/blob/port-absent/C/src/PortAbsentTest.lf

TS target LF program:
https://github.com/lf-lang/examples-lingua-franca/blob/port-absent/TypeScript/src/PortAbsentTest.lf

If you run both of the programs above, you will notice that the C version executes reactions in the order they're defined. However, the TS version executes reactions in a different order.
