### PR TITLE
Fix error with handling multiple reactions in same time(has different microsteps)

### DIFF
--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -91,7 +91,7 @@ export interface TriggerManager {
             // This action has never been scheduled before.
             return false;
         }
-        if (this.tag.isSimultaneousWith(this.runtime.util.getCurrentTag())) {
+        if (this.tag.time.isEqualTo(this.runtime.util.getCurrentLogicalTime())) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
I found that the reactor can't handle multiple reactions at the same time(different microsteps). 

The reason is the location of [`advanceTime`](https://github.com/lf-lang/reactor-ts/blob/reaction-order-fix/src/core/reactor.ts#L2041) in [`next`](https://github.com/lf-lang/reactor-ts/blob/reaction-order-fix/src/core/reactor.ts#L2011). The microstep is already advanced when we do [`this._react`](https://github.com/lf-lang/reactor-ts/blob/reaction-order-fix/src/core/reactor.ts#L2082). 

At this time, the below example doesn't work well in master branch due to this problem.
HelloDistributed.lf: 
https://github.com/lf-lang/lingua-franca/blob/master/test/TypeScript/src/federated/HelloDistributed.lf

When we handle the reaction which is triggered by the tagged message with tag (1sec, 0), and if there is a reaction in the `reactionQ` at the tag (1sec, 1), the return value of [`isPresent`](https://github.com/lf-lang/reactor-ts/blob/reaction-order-fix/src/core/trigger.ts#L89) is false even if the reaction has the value at this logical time. And this makes the reactor ignores the tagged message. 