### PR TITLE
Address CI failure in documentation generation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "microtime": "^3.0.0",
                 "nanotimer": "^0.3.15",
                 "rimraf": "^3.0.2",
-                "typescript": "~4.4.4",
+                "typescript": "~4.8.2",
                 "ulog": "^1.1.0",
                 "uuid": "^8.3.2"
             },
@@ -41,7 +41,7 @@
                 "marked": ">=4.0.10",
                 "parsimmon": "1.13.0",
                 "ts-jest": "^27.0.3",
-                "typedoc": "^0.21.4"
+                "typedoc": "0.23.11"
             }
         },
         "node_modules/@babel/cli": {
@@ -5450,36 +5450,6 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "devOptional": true
         },
-        "node_modules/handlebars": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.5",
-                "neo-async": "^2.6.0",
-                "source-map": "^0.6.1",
-                "wordwrap": "^1.0.0"
-            },
-            "bin": {
-                "handlebars": "bin/handlebars"
-            },
-            "engines": {
-                "node": ">=0.4.7"
-            },
-            "optionalDependencies": {
-                "uglify-js": "^3.1.4"
-            }
-        },
-        "node_modules/handlebars/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9412,6 +9382,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
         "node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -9581,9 +9557,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-            "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+            "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
             "dev": true,
             "bin": {
                 "marked": "bin/marked.js"
@@ -9763,12 +9739,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
-        },
-        "node_modules/neo-async": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
         "node_modules/node-addon-api": {
@@ -9985,30 +9955,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/onigasm": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-            "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^5.1.1"
-            }
-        },
-        "node_modules/onigasm/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/onigasm/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
         },
         "node_modules/optionator": {
             "version": "0.8.3",
@@ -10228,15 +10174,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "optional": true
-        },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
         },
         "node_modules/prompts": {
             "version": "2.4.1",
@@ -10623,14 +10560,14 @@
             }
         },
         "node_modules/shiki": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
-            "integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+            "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
             "dev": true,
             "dependencies": {
-                "json5": "^2.2.0",
-                "onigasm": "^2.2.5",
-                "vscode-textmate": "5.2.0"
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "^6.0.0"
             }
         },
         "node_modules/signal-exit": {
@@ -11364,43 +11301,51 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.4.tgz",
-            "integrity": "sha512-slZQhvD9U0d9KacktYAyuNMMOXJRFNHy+Gd8xY2Qrqq3eTTTv3frv3N4au/cFnab9t3T5WA0Orb6QUjMc+1bDA==",
+            "version": "0.23.11",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.11.tgz",
+            "integrity": "sha512-FhZ2HfqlS++53UwHk4txCsTrTlpYR0So/0osMyBeP1E7llRNRqycJGfYK1qx9Wvvv5VO8tGdpwzOwDW5FrTi7A==",
             "dev": true,
             "dependencies": {
-                "glob": "^7.1.7",
-                "handlebars": "^4.7.7",
                 "lunr": "^2.3.9",
-                "marked": "^2.1.1",
-                "minimatch": "^3.0.0",
-                "progress": "^2.0.3",
-                "shiki": "^0.9.3",
-                "typedoc-default-themes": "^0.12.10"
+                "marked": "^4.0.19",
+                "minimatch": "^5.1.0",
+                "shiki": "^0.11.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
             },
             "engines": {
-                "node": ">= 12.20.0"
+                "node": ">= 14.14"
             },
             "peerDependencies": {
-                "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x"
+                "typescript": "4.6.x || 4.7.x || 4.8.x"
             }
         },
-        "node_modules/typedoc-default-themes": {
-            "version": "0.12.10",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
-            "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
             "engines": {
-                "node": ">= 8"
+                "node": ">=10"
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11415,19 +11360,6 @@
             "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/uglify-js": {
-            "version": "3.13.10",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
-            "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
-            "dev": true,
-            "optional": true,
-            "bin": {
-                "uglifyjs": "bin/uglifyjs"
-            },
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/ulog": {
@@ -11631,10 +11563,16 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
         "node_modules/vscode-textmate": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+            "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
             "dev": true
         },
         "node_modules/w3c-hr-time": {
@@ -11749,12 +11687,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-            "dev": true
         },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",
@@ -16024,27 +15956,6 @@
             "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
             "devOptional": true
         },
-        "handlebars": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5",
-                "neo-async": "^2.6.0",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4",
-                "wordwrap": "^1.0.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -19025,6 +18936,12 @@
                 "minimist": "^1.2.5"
             }
         },
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -19161,9 +19078,9 @@
             }
         },
         "marked": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
-            "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+            "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
             "dev": true
         },
         "merge-stream": {
@@ -19305,12 +19222,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
-        },
-        "neo-async": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
         "node-addon-api": {
@@ -19471,32 +19382,6 @@
                 "mimic-fn": "^2.1.0"
             }
         },
-        "onigasm": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-            "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^5.1.1"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-                    "dev": true
-                }
-            }
-        },
         "optionator": {
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -19648,12 +19533,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "optional": true
-        },
-        "progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true
         },
         "prompts": {
             "version": "2.4.1",
@@ -19965,14 +19844,14 @@
             "dev": true
         },
         "shiki": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
-            "integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+            "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
             "dev": true,
             "requires": {
-                "json5": "^2.2.0",
-                "onigasm": "^2.2.5",
-                "vscode-textmate": "5.2.0"
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "^6.0.0"
             }
         },
         "signal-exit": {
@@ -20552,43 +20431,46 @@
             }
         },
         "typedoc": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.4.tgz",
-            "integrity": "sha512-slZQhvD9U0d9KacktYAyuNMMOXJRFNHy+Gd8xY2Qrqq3eTTTv3frv3N4au/cFnab9t3T5WA0Orb6QUjMc+1bDA==",
+            "version": "0.23.11",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.11.tgz",
+            "integrity": "sha512-FhZ2HfqlS++53UwHk4txCsTrTlpYR0So/0osMyBeP1E7llRNRqycJGfYK1qx9Wvvv5VO8tGdpwzOwDW5FrTi7A==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.7",
-                "handlebars": "^4.7.7",
                 "lunr": "^2.3.9",
-                "marked": "^2.1.1",
-                "minimatch": "^3.0.0",
-                "progress": "^2.0.3",
-                "shiki": "^0.9.3",
-                "typedoc-default-themes": "^0.12.10"
+                "marked": "^4.0.19",
+                "minimatch": "^5.1.0",
+                "shiki": "^0.11.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
-        "typedoc-default-themes": {
-            "version": "0.12.10",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
-            "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
-            "dev": true
-        },
         "typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
         },
         "typical": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
             "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
-        },
-        "uglify-js": {
-            "version": "3.13.10",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
-            "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
-            "dev": true,
-            "optional": true
         },
         "ulog": {
             "version": "1.1.0",
@@ -20744,10 +20626,16 @@
                 "homedir-polyfill": "^1.0.1"
             }
         },
+        "vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
         "vscode-textmate": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+            "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
             "dev": true
         },
         "w3c-hr-time": {
@@ -20840,12 +20728,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
-        },
-        "wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
             "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "check-types": "tsc",
         "install": "npx rimraf lib && npx babel src --out-dir lib --extensions .ts",
         "deploy": "npm run build && npm run doc",
-        "doc": "typedoc --exclude \"**/+(example|benchmark|share)/**/*.ts\" --out docs src && touch docs/.nojekyll",
+        "doc": "typedoc --out docs src/core/index.ts && touch docs/.nojekyll",
         "dtslint": "dtslint __tests__/types",
         "test": "jest --coverage"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "node",
+        "skipLibCheck": true,
         "strictBindCallApply": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,


### PR DESCRIPTION
I do not know why TypeDoc couldn't find our entry point inside the
src folder, but I guess it isn't suprising since I did do a version
bump. I also had to skip lib checking due to issues with Mocha:
https://stackoverflow.com/questions/55680391/typescript-error-ts2403-subsequent-variable-declarations-must-have-the-same-typ

(Note that I think it's a good idea to skip lib checking regardless, since the code we depend on in `reactor-ts` is maintained by other people and should not be our problem. It will save time not to have `tsc` check all that.)