### PR TITLE
Send appropriate upstream connection delays to the RTI

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+ts-upstream-delays

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1150,8 +1150,13 @@ export class FederatedApp extends App {
             this.addDownstreamFederate(sendsToFedId);
         }
         for (let dependsOnFedId of config.dependsOn) {
-            // FIXME: Get delay properly considering the unit instead of hardcoded TimeValue.zero().
-            this.addUpstreamFederate(dependsOnFedId, TimeValue.zero());
+            let minOutputConnectionDelay = TimeValue.FOREVER();
+            for (let candidate of config.upstreamConnectionDelays[dependsOnFedId]) {
+                if (minOutputConnectionDelay.isLaterThan(candidate)) {
+                    minOutputConnectionDelay = candidate;
+                }
+            }
+            this.addUpstreamFederate(dependsOnFedId, minOutputConnectionDelay);
         }
     }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -119,5 +119,6 @@ export interface FederateConfig {
     networkMessageActions: string[]
     rtiHost: string
     rtiPort: number
-    sendsTo: number[]
+    sendsTo: number[],
+    upstreamConnectionDelays: TimeValue[] []
 }


### PR DESCRIPTION
The previous version of this PR is [reactor-ts/pull/125](https://github.com/lf-lang/reactor-ts/pull/125).

This PR addresses This [FIXME](https://github.com/lf-lang/reactor-ts/blob/be7b4f18ce8e40098867a25fe4f59929862038a8/src/core/federation.ts#L1153). 

This PR adds an element `upstreamConnectionDelays` to the `FederateConfig`.
Also, it determines the minimum delays from each upstream federate and adds it to the list, [`upstreamFedDelays`](https://github.com/lf-lang/reactor-ts/blob/be7b4f18ce8e40098867a25fe4f59929862038a8/src/core/federation.ts#L987).