### PR TITLE
Handling of physical connections with after delay in federations

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-ts-upstream-delays
+ts-physical-conn-after-delay

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -145,7 +145,7 @@ export class Dummy extends Action<Present> {
 }
 
 export class FederatePortAction<T extends Present> extends Action<T> {
-    constructor(__parent__: Reactor, origin: Origin) {
-        super(__parent__, origin)
+    constructor(__parent__: Reactor, origin: Origin, minDelay: TimeValue = TimeValue.secs(0)) {
+        super(__parent__, origin, minDelay)
     }
 }


### PR DESCRIPTION
This draft PR tries to fix this [reactor-ts/issues#147](https://github.com/lf-lang/reactor-ts/issues/147).
Relevant Lingua Franca PR: https://github.com/lf-lang/lingua-franca/pull/1676 

In the reactor-ts, the federate execution uses P2P messages to handle physical connections. We have to consider aligning the reactor-ts as the same.