### PR TITLE
Unnecessary field `rtiSynchronized` removed

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-ts-physical-conn-after-delay
+master

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -952,6 +952,7 @@ export class FederatedApp extends App {
      * If this variable is true, logical time in this federate
      * cannot advance beyond the time given in the greatest Time Advance Grant
      * sent from the RTI.
+     * FIXME: This concept is very old and not sure why it is needed.
      */
     private rtiSynchronized: boolean = false;
 

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -947,16 +947,6 @@ export class FederatedApp extends App {
     private rtiClient: RTIClient;
 
     /**
-     * If a federated app uses logical connections, its execution
-     * with respect to time advancement must be sychronized with the RTI.
-     * If this variable is true, logical time in this federate
-     * cannot advance beyond the time given in the greatest Time Advance Grant
-     * sent from the RTI.
-     * FIXME: This concept is very old and not sure why it is needed.
-     */
-    private rtiSynchronized: boolean = false;
-
-    /**
      * Stop request-related information
      * including the current state and the tag associated with the stop requested or stop granted.
      */
@@ -999,13 +989,6 @@ export class FederatedApp extends App {
 
     public registerOutputControlReactionTrigger(outputControlReactionTrigger: Action<Present>) {
         this.outputControlReactionTriggers.push(outputControlReactionTrigger);
-    }
-
-    /**
-     * Getter for rtiSynchronized
-     */
-    public _isRTISynchronized() {
-        return this.rtiSynchronized;
     }
 
     /**
@@ -1057,8 +1040,8 @@ export class FederatedApp extends App {
             tagBarrier = this._getGreatestTimeAdvanceGrant();
         }
 
-        if (this._isRTISynchronized() || tagBarrier !== null) {
-            if (tagBarrier === null || tagBarrier.isSmallerThan(nextEvent.tag)) {
+        if (tagBarrier !== null) {
+            if (tagBarrier.isSmallerThan(nextEvent.tag)) {
                 if (this.minDelayFromPhysicalActionToFederateOutput !== null &&
                     this.downstreamFedIDs.length > 0) {
                         let physicalTime = getCurrentPhysicalTime()
@@ -1164,19 +1147,13 @@ export class FederatedApp extends App {
     /**
      * Register a federate port's action with the federate. It must be registered
      * so it is known by the rtiClient and may be scheduled when a message for the
-     * port has been received via the RTI. If at least one of a federate's actions
-     * is logical, signifying a logical connection to the federate's port,
-     * this FederatedApp must be made RTI synchronized. The advancement of time in
-     * an RTI synchronized FederatedApp is managed by the RTI.
+     * port has been received via the RTI. 
      * @param federatePortID The designated ID for the federate port. For compatability with the
      * C RTI, the ID must be expressable as a 16 bit unsigned short. The ID must be
      * unique among all port IDs on this federate and be a number between 0 and NUMBER_OF_PORTS - 1
      * @param federatePort The federate port's action for registration.
      */
     public registerFederatePortAction<T extends Present>(federatePortID: number, federatePortAction: Action<T>) {
-        if (federatePortAction.origin === Origin.logical) {
-            this.rtiSynchronized = true;
-        }
         this.rtiClient.registerFederatePortAction(federatePortID, federatePortAction);
     }
 


### PR DESCRIPTION
The variable "rtiSynchronized" is only used at [https://github.com/lf-lang/reactor-ts/blob/b5a29738c38222a44b64fc36091e3679e15fe1f7/src/core/federation.ts#L1059](https://github.com/lf-lang/reactor-ts/blob/b5a29738c38222a44b64fc36091e3679e15fe1f7/src/core/federation.ts#L1059)

This prevents the upstream federate with a physical action to schedule dummy events to advance the downstream federate's tag.

I think we can simply remove this concept. The code above is a part of [`_canProceed()`](https://github.com/lf-lang/reactor-ts/blob/b5a29738c38222a44b64fc36091e3679e15fe1f7/src/core/federation.ts#L1049) and this function is called in the [`_next()`](https://github.com/lf-lang/reactor-ts/blob/b5a29738c38222a44b64fc36091e3679e15fe1f7/src/core/reactor.ts#L2074) function. However, there is no comparison like `if (this.isRTISynchronized()...` in the [`lf_next_locked()`](https://github.com/lf-lang/reactor-c/blob/667a5d702cbcd0288328417d8c632e6b5af19c04/core/threaded/reactor_threaded.c#L534) of the reactor-c.