### PR TITLE
Install the RTI while testing and Prevent unintended tag advancement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           repository: lf-lang/lingua-franca
           ref: ${{ env.lingua-franca-ref }}
           fetch-depth: 0
+          submodules: true
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment
@@ -41,6 +42,9 @@ jobs:
           node-version: 18
       - name: Install pnpm
         run: npm i -g pnpm
+      - name: Install RTI
+        uses: ./.github/actions/install-rti
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#${{ github.head_ref || github.ref_name }}"

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+fix-ts-federated-tests

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1036,6 +1036,9 @@ export class FederatedApp extends App {
         // Otherwise, set the tagBarrier using the greated TAG.
         if (this.stopRequestInfo.state === StopRequestState.SENT) {
             tagBarrier = this.stopRequestInfo.tag;
+            if (this.upstreamFedIDs.length === 0 && tagBarrier.isSmallerThan(nextEvent.tag)) {
+                return false;
+            }
         } else {
             tagBarrier = this._getGreatestTimeAdvanceGrant();
         }
@@ -1112,7 +1115,6 @@ export class FederatedApp extends App {
      */
     constructor (config: FederateConfig, success?: () => void, failure?: () => void) {
 
-        console.log(config.keepAlive);
         super(config.executionTimeout, config.keepAlive, config.fast,
             // Let super class (App) call FederateApp's _shutdown in success and failure.
             () => {

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1362,7 +1362,7 @@ export class FederatedApp extends App {
 
         this.rtiClient.on('timeAdvanceGrant', (tag: Tag) => {
             Log.debug(this, () => {return `Time Advance Grant received from RTI for ${tag}.`});
-            if (this.greatestTimeAdvanceGrant === null || this.greatestTimeAdvanceGrant?.isSmallerThan(tag)) {
+            if (this.greatestTimeAdvanceGrant.isSmallerThan(tag)) {
                 // Update the greatest time advance grant and immediately
                 // wake up _next, in case it was blocked by the old time advance grant
                 this.greatestTimeAdvanceGrant = tag;
@@ -1373,7 +1373,7 @@ export class FederatedApp extends App {
 
         this.rtiClient.on('provisionalTimeAdvanceGrant', (tag: Tag) => {
             Log.debug(this, () => {return `Provisional Time Advance Grant received from RTI for ${tag}.`});
-            if (this.greatestTimeAdvanceGrant === null || this.greatestTimeAdvanceGrant?.isSmallerThan(tag)) {
+            if (this.greatestTimeAdvanceGrant.isSmallerThan(tag)) {
                 // Update the greatest time advance grant and immediately
                 // wake up _next, in case it was blocked by the old time advance grant
 

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1040,22 +1040,24 @@ export class FederatedApp extends App {
             tagBarrier = this._getGreatestTimeAdvanceGrant();
         }
 
-        if (tagBarrier.isSmallerThan(nextEvent.tag)) {
-            if (this.minDelayFromPhysicalActionToFederateOutput !== null &&
-                this.downstreamFedIDs.length > 0) {
-                    let physicalTime = getCurrentPhysicalTime()
-                    if (physicalTime.add(this.minDelayFromPhysicalActionToFederateOutput).isEarlierThan(nextEvent.tag.time)) {
-                        Log.debug(this, () => "Adding dummy event for time: " + physicalTime);
-                        this._addDummyEvent(new Tag(physicalTime));
-                        return false;
-                    }
+        if (this.upstreamFedIDs.length !== 0) {
+            if (tagBarrier.isSmallerThan(nextEvent.tag)) {
+                if (this.minDelayFromPhysicalActionToFederateOutput !== null &&
+                    this.downstreamFedIDs.length > 0) {
+                        let physicalTime = getCurrentPhysicalTime()
+                        if (physicalTime.add(this.minDelayFromPhysicalActionToFederateOutput).isEarlierThan(nextEvent.tag.time)) {
+                            Log.debug(this, () => "Adding dummy event for time: " + physicalTime);
+                            this._addDummyEvent(new Tag(physicalTime));
+                            return false;
+                        }
+                }
+                this.sendRTINextEventTag(nextEvent.tag);
+                Log.debug(this, () => "The greatest time advance grant " +
+                    "received from the RTI is less than the timestamp of the " +
+                    "next event on the event queue");
+                Log.global.debug("Exiting _next.");
+                return false;
             }
-            this.sendRTINextEventTag(nextEvent.tag);
-            Log.debug(this, () => "The greatest time advance grant " +
-                "received from the RTI is less than the timestamp of the " +
-                "next event on the event queue");
-            Log.global.debug("Exiting _next.");
-            return false;
         }
         return true;
     }


### PR DESCRIPTION
In this PR, `ci.yml` is modified to install the RTI while testing federated tests, and unintended tag advancement with the `null` value of `greatestTimeAdvanceGrant` is inhibited. 

Relevant PR
https://github.com/lf-lang/lingua-franca/pull/1752

The RTI should be installed while testing to run federated tests.

Also, the `null` value of `greatestTimeAdvanceGrant` means that there was no TAG message yet. Federates should wait for TAG messages. 