### PR TITLE
Index moved from `src/core` to `src`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "@lf-lang/reactor-ts",
     "version": "0.3.4",
     "description": "A reactor-oriented programming framework in TypeScript",
-    "main": "lib/core/index.js",
-    "types": "src/core",
+    "main": "lib/index.js",
+    "types": "src",
     "type": "commonjs",
     "dependencies": {
         "@types/command-line-args": "^5.2.0",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,1 +1,0 @@
-export * from './internal'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './core/internal'


### PR DESCRIPTION
This is done so that `tsc` puts the other `.js` files into `lib/core` even if there are not other files or directories in `src` due to `npm` excluding them based on `.npmignore`.