### PR TITLE
Remove unused imports (reopen #154)

### DIFF
--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -1,5 +1,3 @@
-import commandLineArgs from 'command-line-args';
-import commandLineUsage from 'command-line-usage';
 import {TimeUnit, TimeValue, LogLevel} from './internal';
 
 //---------------------------------------------------------------------//

--- a/src/core/multiport.ts
+++ b/src/core/multiport.ts
@@ -1,5 +1,5 @@
 import {
-    Absent, InPort, IOPort, MultiRead, MultiReadWrite, OutPort, Present, 
+    Absent, InPort, IOPort, MultiRead, OutPort, Present, 
     Reactor, Runtime, WritablePort, Trigger, TriggerManager, Reaction, Component
 } from "./internal";
 import { WritableMultiPort } from "./port";

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -9,7 +9,7 @@
 import {
     TimeValue, Tag, Origin, getCurrentPhysicalTime, Alarm, PrioritySet,
     SortableDependencyGraph, Log, DependencyGraph, Reaction, Priority,
-    Mutation, Procedure, Absent, ArgList, Args, MultiReadWrite, Present,
+    Mutation, Procedure, Absent, ArgList, Args, Present,
     Read, Sched, SchedulableAction, Triggers, Variable, Write, TaggedEvent,
     Component, ScheduledTrigger, Trigger, TriggerManager,
     Action, InPort, IOPort, MultiPort, OutPort, Port, WritablePort, Startup, Shutdown, WritableMultiPort, Dummy


### PR DESCRIPTION
This is addressed, and hopefully resolves https://github.com/lf-lang/reactor-ts/issues/86
Everything removed exists here: https://github.com/lf-lang/lingua-franca/blob/master/org.lflang/src/org/lflang/generator/ts/TSImportPreambleGenerator.kt

I think #154's CICD doesn't work because it tries to get branch reference from this repo only but that PR is from my repo. We might need to change CICD workflow later, but let's fix it here for now......