### PR TITLE
Fix CI workflow by using the correct URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,9 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#${{ github.head_ref || github.ref_name }}"
+          if [[ ${{ github.event_name }} == "pull_request" ]]; then 
+            repo_url="${{ github.event.pull_request.head.repo.git_url }}"; 
+          else 
+            repo_url="git://github.com/lf-lang/reactor-ts.git"; 
+          fi
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="${repo_url}t#${{ github.head_ref || github.ref_name }}"


### PR DESCRIPTION
Merge **either** this or #157.

Right now, the CI/CD uses `"git://github.com/lf-lang/reactor-ts.git#${{ github.head_ref || github.ref_name }}"` as LF reactor runtime. This is not good because PRs from external repositories will fail the CICD test. 

This is one approach to fix it (which I don't like): if it's a PR, get the PR's git URL and set the external reactor to be it.