### PR TITLE
Fix CI workflow by using locally checked out reactor-ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out reactor-ts repository
         uses: actions/checkout@v3
         with: 
-          path: "ts-reactor"
+          path: "reactor-ts"
           fetch-depth: 0
       - name: Read lingua-franca-ref.txt
         run: echo "lingua-franca-ref=$(cat ./reactor-ts/lingua-franca-ref.txt)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Check out reactor-ts repository
         uses: actions/checkout@v3
         with: 
-          path: "reactor-ts-external"
+          path: "reactor-ts"
           fetch-depth: 0
       - name: Read lingua-franca-ref.txt
-        run: echo "lingua-franca-ref=$(cat ./reactor-ts-external/lingua-franca-ref.txt)" >> $GITHUB_ENV
+        run: echo "lingua-franca-ref=$(cat ./reactor-ts/lingua-franca-ref.txt)" >> $GITHUB_ENV
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:
@@ -52,4 +52,4 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="${{ github.workspace }}/reactor-ts-external"
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="file://${{ github.workspace }}/reactor-ts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
-          ./gradlew targetTest -Ptarget=TypeScript -Druntime="file:${{ github.workspace }}/reactor-ts"
+          ./gradlew targetTest -Ptarget=TypeScript -Druntime="file:/${{ github.workspace }}/reactor-ts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           path: "ts-reactor"
           fetch-depth: 0
       - name: Read lingua-franca-ref.txt
-        run: echo echo "lingua-franca-ref=$(cat ./reactor-ts/lingua-franca-ref.txt)" >> $GITHUB_ENV
+        run: echo "lingua-franca-ref=$(cat ./reactor-ts/lingua-franca-ref.txt)" >> $GITHUB_ENV
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Check out reactor-ts repository
         uses: actions/checkout@v3
         with: 
-          path: "reactor-ts"
+          path: "reactor-ts-external"
           fetch-depth: 0
       - name: Read lingua-franca-ref.txt
-        run: echo "lingua-franca-ref=$(cat ./reactor-ts/lingua-franca-ref.txt)" >> $GITHUB_ENV
+        run: echo "lingua-franca-ref=$(cat ./reactor-ts-external/lingua-franca-ref.txt)" >> $GITHUB_ENV
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:
@@ -52,4 +52,4 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="${{ github.workspace }}/ts-reactor"
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="${{ github.workspace }}/reactor-ts-external"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           ref: ${{ env.lingua-franca-ref }}
           fetch-depth: 0
           submodules: true
-          path: "lingua-franca"
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment
@@ -52,6 +51,5 @@ jobs:
         uses: ./.github/actions/install-rti
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
-        working-directory: "./lingua-franca"
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime=${{ github.workspace }}/ts-reactor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime=${{ github.workspace }}/ts-reactor"
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="${{ github.workspace }}/ts-reactor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,13 @@ jobs:
   lingua-franca:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out reactor-ts repository
+        uses: actions/checkout@v3
+        with: 
+          path: "ts-reactor"
+          fetch-depth: 0
       - name: Read lingua-franca-ref.txt
-        run: echo "lingua-franca-ref=$(wget -qO- https://raw.githubusercontent.com/lf-lang/reactor-ts/${{ github.head_ref || github.ref_name }}/lingua-franca-ref.txt)" >> $GITHUB_ENV
+        run: echo echo "lingua-franca-ref=$(cat ./reactor-ts/lingua-franca-ref.txt)" >> $GITHUB_ENV
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:
@@ -34,6 +39,7 @@ jobs:
           ref: ${{ env.lingua-franca-ref }}
           fetch-depth: 0
           submodules: true
+          path: "lingua-franca"
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment
@@ -46,5 +52,6 @@ jobs:
         uses: ./.github/actions/install-rti
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
+        working-directory: "./lingua-franca"
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#${{ github.head_ref || github.ref_name }}"
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime=${{ github.workspace }}/ts-reactor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,13 @@ jobs:
           repository: lf-lang/lingua-franca
           ref: ${{ env.lingua-franca-ref }}
           fetch-depth: 0
+          path: "lingua-franca"
           submodules: true
+      - name: Move Lingua Franca to default pwd
+        run: |
+          shopt -s dotglob
+          mv -- ./lingua-franca/* ${{ github.workspace }}
+          shopt -u dotglob 
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
+          cache-dependency-path: 'reactor-ts/package-lock.json'
+      - name: Build reactor-ts
+        run: |
+          cd ./reactor-ts
+          npm install
+          npm run build
       - name: Install pnpm
         run: npm i -g pnpm
       - name: Install RTI
@@ -60,4 +67,4 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Perform Lingua Franca TypeScript tests
         run: |
-          ./gradlew targetTest -Ptarget=TypeScript -Druntime="file://${{ github.workspace }}/reactor-ts"
+          ./gradlew targetTest -Ptarget=TypeScript -Druntime="file:${{ github.workspace }}/reactor-ts"


### PR DESCRIPTION
Merge either this or #156.

Right now, the CI/CD uses `"git://github.com/lf-lang/reactor-ts.git#${{ github.head_ref || github.ref_name }}"` as LF reactor runtime. This is not good because PRs from external repositories will fail the CICD test.

This is one approach to fix it (which I like): checkout the reactor and let LF use that (the checked out) local reactor.

Squash and rebase merge this PR please. Do not just merge because it will look terrible.

I suppose https://github.com/lf-lang/reactor-ts/tree/lhstrh-patch-1 is trying to fix the same thing but sadly `${{ github.repositoryUrl }}` is still always `lf-lang/reactor-ts`......