### PR TITLE
Remove `Present` and replace with `unknown`; remove Args and Trigger and use TS Tuple

### DIFF
--- a/__tests__/ActionTrigger.test.ts
+++ b/__tests__/ActionTrigger.test.ts
@@ -1,7 +1,6 @@
 import type {Sched} from "../src/core/internal";
 import {
   App,
-  Tuple,
   Origin,
   TimeValue,
   Reactor,
@@ -24,8 +23,8 @@ export class ActionTrigger extends Reactor {
     super(parent);
     // Reaction priorities matter here. The overridden reaction must go first.
     this.addReaction(
-      new Tuple(this.t1),
-      new Tuple(this.schedulable(this.a1)),
+      [this.t1],
+      [this.schedulable(this.a1]),
       /**
        * Schedule the incorrect payload for action a1.
        */
@@ -38,8 +37,8 @@ export class ActionTrigger extends Reactor {
     );
 
     this.addReaction(
-      new Tuple(this.t1),
-      new Tuple(this.schedulable(this.a1), this.a2),
+      [this.t1],
+      [this.schedulable(this.a1], this.a2),
       /**
        * Schedule the correct payload for action a1.
        */
@@ -52,8 +51,8 @@ export class ActionTrigger extends Reactor {
     );
 
     this.addReaction(
-      new Tuple(this.a1),
-      new Tuple(this.a1, this.a2),
+      [this.a1],
+      [this.a1, this.a2],
       /**
        * If the action payload is correct, test is successful. Otherwise it fails.
        * Since a2 was not scheduled it should return null on a call to get() and

--- a/__tests__/ActionTrigger.test.ts
+++ b/__tests__/ActionTrigger.test.ts
@@ -24,7 +24,7 @@ export class ActionTrigger extends Reactor {
     // Reaction priorities matter here. The overridden reaction must go first.
     this.addReaction(
       [this.t1],
-      [this.schedulable(this.a1]),
+      [this.schedulable(this.a1)],
       /**
        * Schedule the incorrect payload for action a1.
        */
@@ -38,7 +38,7 @@ export class ActionTrigger extends Reactor {
 
     this.addReaction(
       [this.t1],
-      [this.schedulable(this.a1], this.a2),
+      [this.schedulable(this.a1), this.a2],
       /**
        * Schedule the correct payload for action a1.
        */

--- a/__tests__/ActionTrigger.test.ts
+++ b/__tests__/ActionTrigger.test.ts
@@ -1,8 +1,7 @@
 import type {Sched} from "../src/core/internal";
 import {
   App,
-  Triggers,
-  Args,
+  Tuple,
   Origin,
   TimeValue,
   Reactor,
@@ -25,8 +24,8 @@ export class ActionTrigger extends Reactor {
     super(parent);
     // Reaction priorities matter here. The overridden reaction must go first.
     this.addReaction(
-      new Triggers(this.t1),
-      new Args(this.schedulable(this.a1)),
+      new Tuple(this.t1),
+      new Tuple(this.schedulable(this.a1)),
       /**
        * Schedule the incorrect payload for action a1.
        */
@@ -39,8 +38,8 @@ export class ActionTrigger extends Reactor {
     );
 
     this.addReaction(
-      new Triggers(this.t1),
-      new Args(this.schedulable(this.a1), this.a2),
+      new Tuple(this.t1),
+      new Tuple(this.schedulable(this.a1), this.a2),
       /**
        * Schedule the correct payload for action a1.
        */
@@ -53,8 +52,8 @@ export class ActionTrigger extends Reactor {
     );
 
     this.addReaction(
-      new Triggers(this.a1),
-      new Args(this.a1, this.a2),
+      new Tuple(this.a1),
+      new Tuple(this.a1, this.a2),
       /**
        * If the action payload is correct, test is successful. Otherwise it fails.
        * Since a2 was not scheduled it should return null on a call to get() and

--- a/__tests__/Adder.test.ts
+++ b/__tests__/Adder.test.ts
@@ -2,7 +2,6 @@ import type {IOPort} from "../src/core/internal";
 import {
   App,
   Reactor,
-  Tuple,
   InPort,
   OutPort
 } from "../src/core/internal";
@@ -18,8 +17,8 @@ export class Adder extends Reactor {
     super(parent);
 
     this.addReaction(
-      new Tuple(this.in1, this.in2),
-      new Tuple(this.in1, this.in2, this.writable(this.out)),
+      [this.in1, this.in2],
+      [this.in1, this.in2, this.writable(this.out]),
       function (this, in1, in2, out) {
         // Type assertions allow coercion of null to 0.
         out.set((in1.get() as number) + (in2.get() as number));

--- a/__tests__/Adder.test.ts
+++ b/__tests__/Adder.test.ts
@@ -2,8 +2,7 @@ import type {IOPort} from "../src/core/internal";
 import {
   App,
   Reactor,
-  Args,
-  Triggers,
+  Tuple,
   InPort,
   OutPort
 } from "../src/core/internal";
@@ -19,8 +18,8 @@ export class Adder extends Reactor {
     super(parent);
 
     this.addReaction(
-      new Triggers(this.in1, this.in2),
-      new Args(this.in1, this.in2, this.writable(this.out)),
+      new Tuple(this.in1, this.in2),
+      new Tuple(this.in1, this.in2, this.writable(this.out)),
       function (this, in1, in2, out) {
         // Type assertions allow coercion of null to 0.
         out.set((in1.get() as number) + (in2.get() as number));

--- a/__tests__/Adder.test.ts
+++ b/__tests__/Adder.test.ts
@@ -1,4 +1,4 @@
-import type {IOPort, Present} from "../src/core/internal";
+import type {IOPort} from "../src/core/internal";
 import {
   App,
   Reactor,
@@ -36,7 +36,7 @@ class MyAdder extends Adder {
     }
   }
 
-  public getProxy(port: IOPort<Present>) {
+  public getProxy(port: IOPort<unknown>) {
     return this.writable(port);
   }
 }

--- a/__tests__/Adder.test.ts
+++ b/__tests__/Adder.test.ts
@@ -18,7 +18,7 @@ export class Adder extends Reactor {
 
     this.addReaction(
       [this.in1, this.in2],
-      [this.in1, this.in2, this.writable(this.out]),
+      [this.in1, this.in2, this.writable(this.out)],
       function (this, in1, in2, out) {
         // Type assertions allow coercion of null to 0.
         out.set((in1.get() as number) + (in2.get() as number));

--- a/__tests__/Adder.test.ts
+++ b/__tests__/Adder.test.ts
@@ -1,10 +1,5 @@
 import type {IOPort} from "../src/core/internal";
-import {
-  App,
-  Reactor,
-  InPort,
-  OutPort
-} from "../src/core/internal";
+import {App, Reactor, InPort, OutPort} from "../src/core/internal";
 
 export class Adder extends Reactor {
   in1 = new InPort<number>(this);

--- a/__tests__/CausalityGraph.test.ts
+++ b/__tests__/CausalityGraph.test.ts
@@ -15,7 +15,7 @@ class Starter extends Reactor {
     super(parent);
     this.addReaction(
       [this.in],
-      [this.in, this.writable(this.out]),
+      [this.in, this.writable(this.out)],
       function (this, __in, __out) {
         __out.set(4);
       }
@@ -32,7 +32,7 @@ class R1 extends Reactor {
     super(parent);
     this.addReaction(
       [this.in],
-      [this.in, this.writable(this.out]),
+      [this.in, this.writable(this.out)],
       function (this, __in, __out) {
         const tmp = __in.get();
         let out = 0;
@@ -56,7 +56,7 @@ class R2 extends Reactor {
     super(parent);
     this.addReaction(
       [this.in],
-      [this.in, this.writable(this.out]),
+      [this.in, this.writable(this.out)],
       function (this, __in, __out) {
         const tmp = __in.get();
         const out = 0;

--- a/__tests__/CausalityGraph.test.ts
+++ b/__tests__/CausalityGraph.test.ts
@@ -1,17 +1,9 @@
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
-  Timer,
+  Tuple,
   OutPort,
   InPort,
-  TimeUnit,
-  TimeValue,
-  Origin,
-  Log,
-  LogLevel,
-  Action
 } from "../src/core/internal";
 
 /* Set a port in startup to get thing going */
@@ -23,8 +15,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in),
-      new Args(this.in, this.writable(this.out)),
+      new Tuple(this.in),
+      new Tuple(this.in, this.writable(this.out)),
       function (this, __in, __out) {
         __out.set(4);
       }
@@ -40,8 +32,8 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in),
-      new Args(this.in, this.writable(this.out)),
+      new Tuple(this.in),
+      new Tuple(this.in, this.writable(this.out)),
       function (this, __in, __out) {
         const tmp = __in.get();
         let out = 0;
@@ -64,8 +56,8 @@ class R2 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in),
-      new Args(this.in, this.writable(this.out)),
+      new Tuple(this.in),
+      new Tuple(this.in, this.writable(this.out)),
       function (this, __in, __out) {
         const tmp = __in.get();
         const out = 0;

--- a/__tests__/CausalityGraph.test.ts
+++ b/__tests__/CausalityGraph.test.ts
@@ -1,9 +1,4 @@
-import {
-  Reactor,
-  App,
-  OutPort,
-  InPort,
-} from "../src/core/internal";
+import {Reactor, App, OutPort, InPort} from "../src/core/internal";
 
 /* Set a port in startup to get thing going */
 class Starter extends Reactor {

--- a/__tests__/CausalityGraph.test.ts
+++ b/__tests__/CausalityGraph.test.ts
@@ -1,7 +1,6 @@
 import {
   Reactor,
   App,
-  Tuple,
   OutPort,
   InPort,
 } from "../src/core/internal";
@@ -15,8 +14,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in),
-      new Tuple(this.in, this.writable(this.out)),
+      [this.in],
+      [this.in, this.writable(this.out]),
       function (this, __in, __out) {
         __out.set(4);
       }
@@ -32,8 +31,8 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in),
-      new Tuple(this.in, this.writable(this.out)),
+      [this.in],
+      [this.in, this.writable(this.out]),
       function (this, __in, __out) {
         const tmp = __in.get();
         let out = 0;
@@ -56,8 +55,8 @@ class R2 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in),
-      new Tuple(this.in, this.writable(this.out)),
+      [this.in],
+      [this.in, this.writable(this.out]),
       function (this, __in, __out) {
         const tmp = __in.get();
         const out = 0;

--- a/__tests__/Clock.test.ts
+++ b/__tests__/Clock.test.ts
@@ -5,7 +5,6 @@ import {
   Action,
   Timer,
   App,
-  Tuple,
   TimeValue,
   TimeUnit,
   Origin
@@ -39,8 +38,8 @@ export class Clock extends App {
   constructor(timeout: TimeValue, success: () => void, fail: () => void) {
     super(timeout, false, false, success, fail);
     this.addReaction(
-      new Tuple(this.t1),
-      new Tuple(this.schedulable(this.a1)),
+      [this.t1],
+      [this.schedulable(this.a1]),
       /**
        * Print tick and schedule a1
        */
@@ -50,8 +49,8 @@ export class Clock extends App {
       }
     );
     this.addReaction(
-      new Tuple(this.t2),
-      new Tuple(this.schedulable(this.a2)),
+      [this.t2],
+      [this.schedulable(this.a2]),
       /**
        * Print tock and schedule a2.
        */
@@ -64,8 +63,8 @@ export class Clock extends App {
     // simultaneosly by both timers, "Cuckoo" should only
     // print once.
     this.addReaction(
-      new Tuple(this.t1, this.t2),
-      new Tuple(this.schedulable(this.a3)),
+      [this.t1, this.t2],
+      [this.schedulable(this.a3]),
       /**
        * Print cuckoo and schedule a3.
        */
@@ -75,8 +74,8 @@ export class Clock extends App {
       }
     );
     this.addReaction(
-      new Tuple(this.a1, this.a2, this.a3),
-      new Tuple(this.a1, this.a2, this.a3),
+      [this.a1, this.a2, this.a3],
+      [this.a1, this.a2, this.a3],
       /**
        * If all the actions are available at logical time 5 seconds from start, the test is successful.
        */

--- a/__tests__/Clock.test.ts
+++ b/__tests__/Clock.test.ts
@@ -39,7 +39,7 @@ export class Clock extends App {
     super(timeout, false, false, success, fail);
     this.addReaction(
       [this.t1],
-      [this.schedulable(this.a1]),
+      [this.schedulable(this.a1)],
       /**
        * Print tick and schedule a1
        */
@@ -50,7 +50,7 @@ export class Clock extends App {
     );
     this.addReaction(
       [this.t2],
-      [this.schedulable(this.a2]),
+      [this.schedulable(this.a2)],
       /**
        * Print tock and schedule a2.
        */
@@ -64,7 +64,7 @@ export class Clock extends App {
     // print once.
     this.addReaction(
       [this.t1, this.t2],
-      [this.schedulable(this.a3]),
+      [this.schedulable(this.a3)],
       /**
        * Print cuckoo and schedule a3.
        */

--- a/__tests__/Clock.test.ts
+++ b/__tests__/Clock.test.ts
@@ -5,8 +5,7 @@ import {
   Action,
   Timer,
   App,
-  Triggers,
-  Args,
+  Tuple,
   TimeValue,
   TimeUnit,
   Origin
@@ -40,8 +39,8 @@ export class Clock extends App {
   constructor(timeout: TimeValue, success: () => void, fail: () => void) {
     super(timeout, false, false, success, fail);
     this.addReaction(
-      new Triggers(this.t1),
-      new Args(this.schedulable(this.a1)),
+      new Tuple(this.t1),
+      new Tuple(this.schedulable(this.a1)),
       /**
        * Print tick and schedule a1
        */
@@ -51,8 +50,8 @@ export class Clock extends App {
       }
     );
     this.addReaction(
-      new Triggers(this.t2),
-      new Args(this.schedulable(this.a2)),
+      new Tuple(this.t2),
+      new Tuple(this.schedulable(this.a2)),
       /**
        * Print tock and schedule a2.
        */
@@ -65,8 +64,8 @@ export class Clock extends App {
     // simultaneosly by both timers, "Cuckoo" should only
     // print once.
     this.addReaction(
-      new Triggers(this.t1, this.t2),
-      new Args(this.schedulable(this.a3)),
+      new Tuple(this.t1, this.t2),
+      new Tuple(this.schedulable(this.a3)),
       /**
        * Print cuckoo and schedule a3.
        */
@@ -76,8 +75,8 @@ export class Clock extends App {
       }
     );
     this.addReaction(
-      new Triggers(this.a1, this.a2, this.a3),
-      new Args(this.a1, this.a2, this.a3),
+      new Tuple(this.a1, this.a2, this.a3),
+      new Tuple(this.a1, this.a2, this.a3),
       /**
        * If all the actions are available at logical time 5 seconds from start, the test is successful.
        */

--- a/__tests__/InvalidMutations.ts
+++ b/__tests__/InvalidMutations.ts
@@ -1,19 +1,9 @@
 import {
   Reactor,
-  State,
-  Bank,
   App,
-  Triggers,
-  Args,
-  Timer,
+  Tuple,
   OutPort,
-  InPort,
-  TimeUnit,
-  TimeValue,
-  Origin,
-  Log,
-  LogLevel,
-  Action
+  InPort
 } from "../src/core/internal";
 
 class Starter extends Reactor {
@@ -22,8 +12,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.writable(this.out)),
+      new Tuple(this.startup),
+      new Tuple(this.writable(this.out)),
       function (this, __out) {
         __out.set(4);
       }
@@ -43,16 +33,16 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in1),
-      new Args(this.in1, this.writable(this.out1)),
+      new Tuple(this.in1),
+      new Tuple(this.in1, this.writable(this.out1)),
       function (this, __in, __out) {
         __out.set(4);
       }
     );
 
     this.addMutation(
-      new Triggers(this.in1),
-      new Args(this.in1, this.in2, this.out1, this.out2),
+      new Tuple(this.in1),
+      new Tuple(this.in1, this.in2, this.out1, this.out2),
       function (this, __in1, __in2, __out1, __out2) {
         test("expect error on creating creating direct feed through", () => {
           expect(() => {

--- a/__tests__/InvalidMutations.ts
+++ b/__tests__/InvalidMutations.ts
@@ -1,9 +1,4 @@
-import {
-  Reactor,
-  App,
-  OutPort,
-  InPort
-} from "../src/core/internal";
+import {Reactor, App, OutPort, InPort} from "../src/core/internal";
 
 class Starter extends Reactor {
   public out = new OutPort<number>(this);

--- a/__tests__/InvalidMutations.ts
+++ b/__tests__/InvalidMutations.ts
@@ -12,7 +12,7 @@ class Starter extends Reactor {
     super(parent);
     this.addReaction(
       [this.startup],
-      [this.writable(this.out]),
+      [this.writable(this.out)],
       function (this, __out) {
         __out.set(4);
       }
@@ -33,7 +33,7 @@ class R1 extends Reactor {
     super(parent);
     this.addReaction(
       [this.in1],
-      [this.in1, this.writable(this.out1]),
+      [this.in1, this.writable(this.out1)],
       function (this, __in, __out) {
         __out.set(4);
       }

--- a/__tests__/InvalidMutations.ts
+++ b/__tests__/InvalidMutations.ts
@@ -1,7 +1,6 @@
 import {
   Reactor,
   App,
-  Tuple,
   OutPort,
   InPort
 } from "../src/core/internal";
@@ -12,8 +11,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.writable(this.out)),
+      [this.startup],
+      [this.writable(this.out]),
       function (this, __out) {
         __out.set(4);
       }
@@ -33,16 +32,16 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in1),
-      new Tuple(this.in1, this.writable(this.out1)),
+      [this.in1],
+      [this.in1, this.writable(this.out1]),
       function (this, __in, __out) {
         __out.set(4);
       }
     );
 
     this.addMutation(
-      new Tuple(this.in1),
-      new Tuple(this.in1, this.in2, this.out1, this.out2),
+      [this.in1],
+      [this.in1, this.in2, this.out1, this.out2],
       function (this, __in1, __in2, __out1, __out2) {
         test("expect error on creating creating direct feed through", () => {
           expect(() => {

--- a/__tests__/OutputEvent.test.ts
+++ b/__tests__/OutputEvent.test.ts
@@ -2,7 +2,6 @@ import {
   App,
   Reactor,
   Parameter,
-  Tuple,
   TimeValue
 } from "../src/core/internal";
 import {SingleEvent} from "../src/share/SingleEvent";
@@ -17,8 +16,8 @@ export class OutputResponder extends Reactor {
   constructor(__parent__: Reactor) {
     super(__parent__);
     this.addReaction(
-      new Tuple(this.se.o),
-      new Tuple(),
+      [this.se.o],
+      [],
       /**
        * If this reaction is triggered by an output event from the contained reactor,
        * succeed the test.

--- a/__tests__/OutputEvent.test.ts
+++ b/__tests__/OutputEvent.test.ts
@@ -1,9 +1,4 @@
-import {
-  App,
-  Reactor,
-  Parameter,
-  TimeValue
-} from "../src/core/internal";
+import {App, Reactor, Parameter, TimeValue} from "../src/core/internal";
 import {SingleEvent} from "../src/share/SingleEvent";
 
 /**

--- a/__tests__/OutputEvent.test.ts
+++ b/__tests__/OutputEvent.test.ts
@@ -2,8 +2,7 @@ import {
   App,
   Reactor,
   Parameter,
-  Args,
-  Triggers,
+  Tuple,
   TimeValue
 } from "../src/core/internal";
 import {SingleEvent} from "../src/share/SingleEvent";
@@ -18,8 +17,8 @@ export class OutputResponder extends Reactor {
   constructor(__parent__: Reactor) {
     super(__parent__);
     this.addReaction(
-      new Triggers(this.se.o),
-      new Args(),
+      new Tuple(this.se.o),
+      new Tuple(),
       /**
        * If this reaction is triggered by an output event from the contained reactor,
        * succeed the test.

--- a/__tests__/OutputGet.test.ts
+++ b/__tests__/OutputGet.test.ts
@@ -21,7 +21,7 @@ class OutputGetTest extends App {
     Log.global.debug(">>>>>>>>----" + this.util);
     this.addReaction(
       [this.t],
-      [this.writable(this.o]),
+      [this.writable(this.o)],
       function (this, o) {
         Log.global.debug(">>>>>>>>>>being triggered>>>>>>>>>>>");
         if (o.get() != null) {

--- a/__tests__/OutputGet.test.ts
+++ b/__tests__/OutputGet.test.ts
@@ -1,7 +1,6 @@
 import {
   App,
   Timer,
-  Tuple,
   OutPort,
   TimeValue,
   Log
@@ -21,8 +20,8 @@ class OutputGetTest extends App {
     super(timeout, true, false, success, failure);
     Log.global.debug(">>>>>>>>----" + this.util);
     this.addReaction(
-      new Tuple(this.t),
-      new Tuple(this.writable(this.o)),
+      [this.t],
+      [this.writable(this.o]),
       function (this, o) {
         Log.global.debug(">>>>>>>>>>being triggered>>>>>>>>>>>");
         if (o.get() != null) {

--- a/__tests__/OutputGet.test.ts
+++ b/__tests__/OutputGet.test.ts
@@ -1,9 +1,7 @@
 import {
   App,
   Timer,
-  Write,
-  Triggers,
-  Args,
+  Tuple,
   OutPort,
   TimeValue,
   Log
@@ -23,8 +21,8 @@ class OutputGetTest extends App {
     super(timeout, true, false, success, failure);
     Log.global.debug(">>>>>>>>----" + this.util);
     this.addReaction(
-      new Triggers(this.t),
-      new Args(this.writable(this.o)),
+      new Tuple(this.t),
+      new Tuple(this.writable(this.o)),
       function (this, o) {
         Log.global.debug(">>>>>>>>>>being triggered>>>>>>>>>>>");
         if (o.get() != null) {

--- a/__tests__/OutputGet.test.ts
+++ b/__tests__/OutputGet.test.ts
@@ -1,10 +1,4 @@
-import {
-  App,
-  Timer,
-  OutPort,
-  TimeValue,
-  Log
-} from "../src/core/internal";
+import {App, Timer, OutPort, TimeValue, Log} from "../src/core/internal";
 
 class OutputGetTest extends App {
   o: OutPort<number> = new OutPort<number>(this);
@@ -19,24 +13,20 @@ class OutputGetTest extends App {
   ) {
     super(timeout, true, false, success, failure);
     Log.global.debug(">>>>>>>>----" + this.util);
-    this.addReaction(
-      [this.t],
-      [this.writable(this.o)],
-      function (this, o) {
-        Log.global.debug(">>>>>>>>>>being triggered>>>>>>>>>>>");
-        if (o.get() != null) {
-          throw new Error(
-            "Calling get on an output before it has been set does not return null"
-          );
-        }
-        o.set(5);
-        if (o.get() !== 5) {
-          throw new Error(
-            "Calling get on an output after it has been set does not return the set value"
-          );
-        }
+    this.addReaction([this.t], [this.writable(this.o)], function (this, o) {
+      Log.global.debug(">>>>>>>>>>being triggered>>>>>>>>>>>");
+      if (o.get() != null) {
+        throw new Error(
+          "Calling get on an output before it has been set does not return null"
+        );
       }
-    );
+      o.set(5);
+      if (o.get() !== 5) {
+        throw new Error(
+          "Calling get on an output after it has been set does not return the set value"
+        );
+      }
+    });
   }
 }
 

--- a/__tests__/SimpleMutation.test.ts
+++ b/__tests__/SimpleMutation.test.ts
@@ -13,7 +13,7 @@ class Starter extends Reactor {
     super(parent);
     this.addReaction(
       [this.startup],
-      [this.writable(this.out]),
+      [this.writable(this.out)],
       function (this, __out) {
         __out.set(4);
       }
@@ -30,7 +30,7 @@ class R1 extends Reactor {
     super(parent);
     this.addReaction(
       [this.in],
-      [this.in, this.writable(this.out]),
+      [this.in, this.writable(this.out)],
       function (this, __in, __out) {
         __out.set(4);
       }

--- a/__tests__/SimpleMutation.test.ts
+++ b/__tests__/SimpleMutation.test.ts
@@ -1,17 +1,9 @@
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
-  Timer,
   OutPort,
   InPort,
-  TimeUnit,
-  TimeValue,
-  Origin,
-  Log,
-  LogLevel,
-  Action
+  Tuple
 } from "../src/core/internal";
 
 /* Set a port in startup to get thing going */
@@ -21,8 +13,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.writable(this.out)),
+      new Tuple(this.startup),
+      new Tuple(this.writable(this.out)),
       function (this, __out) {
         __out.set(4);
       }
@@ -38,8 +30,8 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in),
-      new Args(this.in, this.writable(this.out)),
+      new Tuple(this.in),
+      new Tuple(this.in, this.writable(this.out)),
       function (this, __in, __out) {
         __out.set(4);
       }
@@ -55,8 +47,8 @@ class R2 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addMutation(
-      new Triggers(this.in),
-      new Args(this.in, this.out),
+      new Tuple(this.in),
+      new Tuple(this.in, this.out),
       function (this, __in, __out) {
         test("expect error to be thrown", () => {
           expect(() => {

--- a/__tests__/SimpleMutation.test.ts
+++ b/__tests__/SimpleMutation.test.ts
@@ -1,9 +1,4 @@
-import {
-  Reactor,
-  App,
-  OutPort,
-  InPort,
-} from "../src/core/internal";
+import {Reactor, App, OutPort, InPort} from "../src/core/internal";
 
 /* Set a port in startup to get thing going */
 class Starter extends Reactor {

--- a/__tests__/SimpleMutation.test.ts
+++ b/__tests__/SimpleMutation.test.ts
@@ -3,7 +3,6 @@ import {
   App,
   OutPort,
   InPort,
-  Tuple
 } from "../src/core/internal";
 
 /* Set a port in startup to get thing going */
@@ -13,8 +12,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.writable(this.out)),
+      [this.startup],
+      [this.writable(this.out]),
       function (this, __out) {
         __out.set(4);
       }
@@ -30,8 +29,8 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in),
-      new Tuple(this.in, this.writable(this.out)),
+      [this.in],
+      [this.in, this.writable(this.out]),
       function (this, __in, __out) {
         __out.set(4);
       }
@@ -47,8 +46,8 @@ class R2 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addMutation(
-      new Tuple(this.in),
-      new Tuple(this.in, this.out),
+      [this.in],
+      [this.in, this.out],
       function (this, __in, __out) {
         test("expect error to be thrown", () => {
           expect(() => {

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -5,8 +5,7 @@ import {
   App,
   Origin,
   TimeValue,
-  Triggers,
-  Args
+  Tuple
 } from "../src/core/internal";
 
 let intendedTagDelay: TimeValue | undefined;
@@ -21,8 +20,8 @@ class ReactorWithFederatePortAction extends App {
   constructor() {
     super(TimeValue.msec(1));
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.schedulable(this.a)),
+      new Tuple(this.startup),
+      new Tuple(this.schedulable(this.a)),
       function (this, a) {
         startUpTag = this.util.getCurrentTag();
         a.schedule(0, 0);
@@ -30,8 +29,8 @@ class ReactorWithFederatePortAction extends App {
     );
 
     this.addReaction(
-      new Triggers(this.a),
-      new Args(this.schedulable(this.f)),
+      new Tuple(this.a),
+      new Tuple(this.schedulable(this.f)),
       function (this, f) {
         let intendedTag: Tag | undefined;
         if (intendedTagDelay === undefined) {

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -20,7 +20,7 @@ class ReactorWithFederatePortAction extends App {
     super(TimeValue.msec(1));
     this.addReaction(
       [this.startup],
-      [this.schedulable(this.a]),
+      [this.schedulable(this.a)],
       function (this, a) {
         startUpTag = this.util.getCurrentTag();
         a.schedule(0, 0);
@@ -29,7 +29,7 @@ class ReactorWithFederatePortAction extends App {
 
     this.addReaction(
       [this.a],
-      [this.schedulable(this.f]),
+      [this.schedulable(this.f)],
       function (this, f) {
         let intendedTag: Tag | undefined;
         if (intendedTagDelay === undefined) {

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -5,7 +5,6 @@ import {
   App,
   Origin,
   TimeValue,
-  Tuple
 } from "../src/core/internal";
 
 let intendedTagDelay: TimeValue | undefined;
@@ -20,8 +19,8 @@ class ReactorWithFederatePortAction extends App {
   constructor() {
     super(TimeValue.msec(1));
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.schedulable(this.a)),
+      [this.startup],
+      [this.schedulable(this.a]),
       function (this, a) {
         startUpTag = this.util.getCurrentTag();
         a.schedule(0, 0);
@@ -29,8 +28,8 @@ class ReactorWithFederatePortAction extends App {
     );
 
     this.addReaction(
-      new Tuple(this.a),
-      new Tuple(this.schedulable(this.f)),
+      [this.a],
+      [this.schedulable(this.f]),
       function (this, f) {
         let intendedTag: Tag | undefined;
         if (intendedTagDelay === undefined) {

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -4,7 +4,7 @@ import {
   FederatePortAction,
   App,
   Origin,
-  TimeValue,
+  TimeValue
 } from "../src/core/internal";
 
 let intendedTagDelay: TimeValue | undefined;
@@ -27,21 +27,17 @@ class ReactorWithFederatePortAction extends App {
       }
     );
 
-    this.addReaction(
-      [this.a],
-      [this.schedulable(this.f)],
-      function (this, f) {
-        let intendedTag: Tag | undefined;
-        if (intendedTagDelay === undefined) {
-          intendedTag = undefined;
-        } else {
-          intendedTag = startUpTag
-            .getLaterTag(intendedTagDelay)
-            .getMicroStepsLater(intendedTagMicrostepDelay);
-        }
-        f.schedule(0, 0, intendedTag);
+    this.addReaction([this.a], [this.schedulable(this.f)], function (this, f) {
+      let intendedTag: Tag | undefined;
+      if (intendedTagDelay === undefined) {
+        intendedTag = undefined;
+      } else {
+        intendedTag = startUpTag
+          .getLaterTag(intendedTagDelay)
+          .getMicroStepsLater(intendedTagMicrostepDelay);
       }
-    );
+      f.schedule(0, 0, intendedTag);
+    });
   }
 
   public setLastTagProvisional(value: boolean) {

--- a/__tests__/bank.ts
+++ b/__tests__/bank.ts
@@ -3,8 +3,7 @@ import {
   Reactor,
   App,
   Timer,
-  Triggers,
-  Args,
+  Tuple,
   OutPort,
   InPort,
   TimeValue,
@@ -20,7 +19,7 @@ class Periodic extends Reactor {
   constructor(parent: Reactor) {
     super(parent);
     const writer = this.writable(this.o);
-    this.addReaction(new Triggers(this.t), new Args(this.t), function (this) {
+    this.addReaction(new Tuple(this.t), new Tuple(this.t), function (this) {
       console.log(this.getBankIndex());
     });
   }
@@ -33,7 +32,7 @@ class MultiPeriodic extends Reactor {
 
   constructor(parent: Reactor) {
     super(parent);
-    this.addReaction(new Triggers(this.t), new Args(this.t), function (this) {
+    this.addReaction(new Tuple(this.t), new Tuple(this.t), function (this) {
       console.log(this.getBankIndex());
     });
   }
@@ -55,7 +54,7 @@ describe("Check bank index", () => {
       super();
       const ports = new Array<OutPort<number>>();
       const multiPorts = new Array<OutMultiPort<number>>();
-      test("throw error on mismatch in lenght of ports", () => {
+      test("throw error on mismatch in length of ports", () => {
         expect(() => this.b.writable(ports)).toThrowError(
           "Length of ports does not match length of reactors."
         );

--- a/__tests__/bank.ts
+++ b/__tests__/bank.ts
@@ -3,7 +3,6 @@ import {
   Reactor,
   App,
   Timer,
-  Tuple,
   OutPort,
   InPort,
   TimeValue,
@@ -19,7 +18,7 @@ class Periodic extends Reactor {
   constructor(parent: Reactor) {
     super(parent);
     const writer = this.writable(this.o);
-    this.addReaction(new Tuple(this.t), new Tuple(this.t), function (this) {
+    this.addReaction([this.t], [this.t], function (this) {
       console.log(this.getBankIndex());
     });
   }
@@ -32,7 +31,7 @@ class MultiPeriodic extends Reactor {
 
   constructor(parent: Reactor) {
     super(parent);
-    this.addReaction(new Tuple(this.t), new Tuple(this.t), function (this) {
+    this.addReaction([this.t], [this.t], function (this) {
       console.log(this.getBankIndex());
     });
   }

--- a/__tests__/bank.ts
+++ b/__tests__/bank.ts
@@ -1,4 +1,3 @@
-import type {Present} from "../src/core/internal";
 import {
   Bank,
   Reactor,
@@ -40,7 +39,7 @@ class MultiPeriodic extends Reactor {
   }
 }
 
-class Generic<T extends Present> extends Reactor {
+class Generic<T> extends Reactor {
   input = new InPort<T>(this);
 }
 

--- a/__tests__/connection.test.ts
+++ b/__tests__/connection.test.ts
@@ -60,7 +60,7 @@ describe("Check _connect", () => {
       super(container);
       this.addReaction(
         [this.startup],
-        [this.writable(this.out]),
+        [this.writable(this.out)],
         function (this, __out) {
           __out.set(100);
         }

--- a/__tests__/connection.test.ts
+++ b/__tests__/connection.test.ts
@@ -3,7 +3,6 @@ import {
   App,
   State,
   OutPort,
-  Tuple,
   InPort,
   TimeUnit,
   TimeValue
@@ -60,8 +59,8 @@ describe("Check _connect", () => {
     constructor(container: Reactor) {
       super(container);
       this.addReaction(
-        new Tuple(this.startup),
-        new Tuple(this.writable(this.out)),
+        [this.startup],
+        [this.writable(this.out]),
         function (this, __out) {
           __out.set(100);
         }
@@ -76,8 +75,8 @@ describe("Check _connect", () => {
     constructor(container: Reactor) {
       super(container);
       this.addReaction(
-        new Tuple(this.in),
-        new Tuple(this.in, this.received),
+        [this.in],
+        [this.in, this.received],
         function (this, __in, __received) {
           const tmp = __in.get();
           try {

--- a/__tests__/connection.test.ts
+++ b/__tests__/connection.test.ts
@@ -1,10 +1,9 @@
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
   State,
   OutPort,
+  Tuple,
   InPort,
   TimeUnit,
   TimeValue
@@ -61,8 +60,8 @@ describe("Check _connect", () => {
     constructor(container: Reactor) {
       super(container);
       this.addReaction(
-        new Triggers(this.startup),
-        new Args(this.writable(this.out)),
+        new Tuple(this.startup),
+        new Tuple(this.writable(this.out)),
         function (this, __out) {
           __out.set(100);
         }
@@ -77,8 +76,8 @@ describe("Check _connect", () => {
     constructor(container: Reactor) {
       super(container);
       this.addReaction(
-        new Triggers(this.in),
-        new Args(this.in, this.received),
+        new Tuple(this.in),
+        new Tuple(this.in, this.received),
         function (this, __in, __received) {
           const tmp = __in.get();
           try {

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -2,11 +2,10 @@ import {Priority, Sortable, ReactionGraph} from "../src/core/internal";
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
   InPort,
   SortablePrecedenceGraph,
   PrioritySet,
+  Tuple,
   Log,
   StringUtil
 } from "../src/core/internal";
@@ -19,7 +18,7 @@ class R extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     for (let i = 0; i < 7; i++) {
-      this.addReaction(new Triggers(this.in), new Args(), function (this) {
+      this.addReaction(new Tuple(this.in), new Tuple(), function (this) {
         throw new Error("Method not implemented.");
       });
     }
@@ -35,7 +34,7 @@ class SR extends Reactor {
 
   constructor(parent: Reactor | null) {
     super(parent);
-    this.addReaction(new Triggers(this.in), new Args(), function (this) {
+    this.addReaction(new Tuple(this.in), new Tuple(), function (this) {
       throw new Error("Method not implemented.");
     });
   }

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -5,7 +5,6 @@ import {
   InPort,
   SortablePrecedenceGraph,
   PrioritySet,
-  Tuple,
   Log,
   StringUtil
 } from "../src/core/internal";
@@ -18,7 +17,7 @@ class R extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     for (let i = 0; i < 7; i++) {
-      this.addReaction(new Tuple(this.in), new Tuple(), function (this) {
+      this.addReaction([this.in], [], function (this) {
         throw new Error("Method not implemented.");
       });
     }
@@ -34,7 +33,7 @@ class SR extends Reactor {
 
   constructor(parent: Reactor | null) {
     super(parent);
-    this.addReaction(new Tuple(this.in), new Tuple(), function (this) {
+    this.addReaction([this.in], [], function (this) {
       throw new Error("Method not implemented.");
     });
   }

--- a/__tests__/disconnect.test.ts
+++ b/__tests__/disconnect.test.ts
@@ -21,7 +21,7 @@ class Starter extends Reactor {
     super(parent);
     this.addReaction(
       [this.startup],
-      [this.writable(this.out]),
+      [this.writable(this.out)],
       function (this, __out) {
         __out.set(4);
       }
@@ -42,7 +42,7 @@ class R1 extends Reactor {
     super(parent);
     this.addReaction(
       [this.in1],
-      [this.in1, this.writable(this.out1]),
+      [this.in1, this.writable(this.out1)],
       function (this, __in, __out) {
         __out.set(4);
       }

--- a/__tests__/disconnect.test.ts
+++ b/__tests__/disconnect.test.ts
@@ -3,8 +3,7 @@ import {
   State,
   Bank,
   App,
-  Triggers,
-  Args,
+  Tuple,
   Timer,
   OutPort,
   InPort,
@@ -22,8 +21,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.writable(this.out)),
+      new Tuple(this.startup),
+      new Tuple(this.writable(this.out)),
       function (this, __out) {
         __out.set(4);
       }
@@ -43,16 +42,16 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in1),
-      new Args(this.in1, this.writable(this.out1)),
+      new Tuple(this.in1),
+      new Tuple(this.in1, this.writable(this.out1)),
       function (this, __in, __out) {
         __out.set(4);
       }
     );
 
     this.addMutation(
-      new Triggers(this.in1),
-      new Args(this.in1, this.in2, this.out2),
+      new Tuple(this.in1),
+      new Tuple(this.in1, this.in2, this.out2),
       function (this, __in1, __in2, __out2) {
         const R2 = new R1(this.getReactor());
         test("expect that disconnecting an existing connection will not result in an error being thrown", () => {

--- a/__tests__/disconnect.test.ts
+++ b/__tests__/disconnect.test.ts
@@ -3,7 +3,6 @@ import {
   State,
   Bank,
   App,
-  Tuple,
   Timer,
   OutPort,
   InPort,
@@ -21,8 +20,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.writable(this.out)),
+      [this.startup],
+      [this.writable(this.out]),
       function (this, __out) {
         __out.set(4);
       }
@@ -42,16 +41,16 @@ class R1 extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in1),
-      new Tuple(this.in1, this.writable(this.out1)),
+      [this.in1],
+      [this.in1, this.writable(this.out1]),
       function (this, __in, __out) {
         __out.set(4);
       }
     );
 
     this.addMutation(
-      new Tuple(this.in1),
-      new Tuple(this.in1, this.in2, this.out2),
+      [this.in1],
+      [this.in1, this.in2, this.out2],
       function (this, __in1, __in2, __out2) {
         const R2 = new R1(this.getReactor());
         test("expect that disconnecting an existing connection will not result in an error being thrown", () => {

--- a/__tests__/multiport.test.ts
+++ b/__tests__/multiport.test.ts
@@ -5,7 +5,7 @@ import {
   OutMultiPort,
   IOPort,
   OutPort,
-  InPort,
+  InPort
 } from "../src/core/internal";
 class TwoInTwoOut extends Reactor {
   inp = new InMultiPort<number>(this, 2);
@@ -47,30 +47,22 @@ class TwoInTwoOut extends Reactor {
       expect(this.inp.width()).toBe(2);
       expect(writer.width()).toBe(2);
     });
-    this.addReaction(
-      [this.inp],
-      [this.inp],
-      function (this, inp) {
-        test("check read values", () => {
-          expect(inp.channel(0).get()).toBe(42);
-          expect(inp.get(0)).toBe(42);
-          expect(inp.channel(1).get()).toBe(69);
-          expect(inp.get(1)).toBe(69);
-          expect(inp.values()).toEqual([42, 69]);
-        });
-        test("print input port names", () => {
-          expect(inp._getName()).toBe("inp");
-          expect(inp.channel(0)._getName()).toBe("inp[0]");
-          expect(inp.channel(1)._getName()).toBe("inp[1]");
-          expect(inp.channel(0)._getFullyQualifiedName()).toBe(
-            "myApp.y.inp[0]"
-          );
-          expect(inp.channel(1)._getFullyQualifiedName()).toBe(
-            "myApp.y.inp[1]"
-          );
-        });
-      }
-    );
+    this.addReaction([this.inp], [this.inp], function (this, inp) {
+      test("check read values", () => {
+        expect(inp.channel(0).get()).toBe(42);
+        expect(inp.get(0)).toBe(42);
+        expect(inp.channel(1).get()).toBe(69);
+        expect(inp.get(1)).toBe(69);
+        expect(inp.values()).toEqual([42, 69]);
+      });
+      test("print input port names", () => {
+        expect(inp._getName()).toBe("inp");
+        expect(inp.channel(0)._getName()).toBe("inp[0]");
+        expect(inp.channel(1)._getName()).toBe("inp[1]");
+        expect(inp.channel(0)._getFullyQualifiedName()).toBe("myApp.y.inp[0]");
+        expect(inp.channel(1)._getFullyQualifiedName()).toBe("myApp.y.inp[1]");
+      });
+    });
     this.addReaction(
       [this.startup],
       [this.allWritable(this.out)],

--- a/__tests__/multiport.test.ts
+++ b/__tests__/multiport.test.ts
@@ -73,7 +73,7 @@ class TwoInTwoOut extends Reactor {
     );
     this.addReaction(
       [this.startup],
-      [this.allWritable(this.out]),
+      [this.allWritable(this.out)],
       function (out) {
         test("start up reaction triggered", () => {
           expect(true).toBe(true);

--- a/__tests__/multiport.test.ts
+++ b/__tests__/multiport.test.ts
@@ -1,13 +1,12 @@
 import {
-  Args,
-  Triggers,
   Reactor,
   App,
   InMultiPort,
   OutMultiPort,
   IOPort,
   OutPort,
-  InPort
+  InPort,
+  Tuple
 } from "../src/core/internal";
 class TwoInTwoOut extends Reactor {
   inp = new InMultiPort<number>(this, 2);
@@ -50,8 +49,8 @@ class TwoInTwoOut extends Reactor {
       expect(writer.width()).toBe(2);
     });
     this.addReaction(
-      new Triggers(this.inp),
-      new Args(this.inp),
+      new Tuple(this.inp),
+      new Tuple(this.inp),
       function (this, inp) {
         test("check read values", () => {
           expect(inp.channel(0).get()).toBe(42);
@@ -74,8 +73,8 @@ class TwoInTwoOut extends Reactor {
       }
     );
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.allWritable(this.out)),
+      new Tuple(this.startup),
+      new Tuple(this.allWritable(this.out)),
       function (out) {
         test("start up reaction triggered", () => {
           expect(true).toBe(true);

--- a/__tests__/multiport.test.ts
+++ b/__tests__/multiport.test.ts
@@ -6,7 +6,6 @@ import {
   IOPort,
   OutPort,
   InPort,
-  Tuple
 } from "../src/core/internal";
 class TwoInTwoOut extends Reactor {
   inp = new InMultiPort<number>(this, 2);
@@ -49,8 +48,8 @@ class TwoInTwoOut extends Reactor {
       expect(writer.width()).toBe(2);
     });
     this.addReaction(
-      new Tuple(this.inp),
-      new Tuple(this.inp),
+      [this.inp],
+      [this.inp],
       function (this, inp) {
         test("check read values", () => {
           expect(inp.channel(0).get()).toBe(42);
@@ -73,8 +72,8 @@ class TwoInTwoOut extends Reactor {
       }
     );
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.allWritable(this.out)),
+      [this.startup],
+      [this.allWritable(this.out]),
       function (out) {
         test("start up reaction triggered", () => {
           expect(true).toBe(true);

--- a/__tests__/mutations.test.ts
+++ b/__tests__/mutations.test.ts
@@ -4,7 +4,7 @@ import {
   Timer,
   OutPort,
   InPort,
-  TimeValue,
+  TimeValue
 } from "../src/core/internal";
 
 class Source extends Reactor {
@@ -51,28 +51,24 @@ class Print extends Reactor {
 
   constructor(owner: Reactor) {
     super(owner);
-    this.addReaction(
-      [this.input],
-      [this.input],
-      function (this, input) {
-        const val = input.get();
-        console.log("Print reacting...");
-        if (val !== undefined) {
-          const expected = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-          for (let i = 0; i < 10; i++) {
-            if (val[i] != expected[i]) {
-              this.util.requestErrorStop(
-                "Expected: " + expected + " but got: " + val
-              );
-              return;
-            }
+    this.addReaction([this.input], [this.input], function (this, input) {
+      const val = input.get();
+      console.log("Print reacting...");
+      if (val !== undefined) {
+        const expected = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        for (let i = 0; i < 10; i++) {
+          if (val[i] != expected[i]) {
+            this.util.requestErrorStop(
+              "Expected: " + expected + " but got: " + val
+            );
+            return;
           }
-          console.log("Expected: " + expected + " and got: " + val);
-        } else {
-          this.util.requestErrorStop("Input undefined.");
         }
+        console.log("Expected: " + expected + " and got: " + val);
+      } else {
+        this.util.requestErrorStop("Input undefined.");
       }
-    );
+    });
   }
 }
 
@@ -86,24 +82,20 @@ class Computer extends Reactor {
   constructor(container: Reactor) {
     super(container);
     this._connect(this.in, this.adder.input);
-    this.addMutation(
-      [this.in],
-      [this.in],
-      function (this, src) {
-        const vals = src.get();
-        if (vals) {
-          let skip = true;
-          for (const id of vals.keys()) {
-            if (skip) {
-              skip = false;
-              continue;
-            }
-            const x = new AddOne(this.getReactor(), id);
-            this.connect(src, x.input);
+    this.addMutation([this.in], [this.in], function (this, src) {
+      const vals = src.get();
+      if (vals) {
+        let skip = true;
+        for (const id of vals.keys()) {
+          if (skip) {
+            skip = false;
+            continue;
           }
+          const x = new AddOne(this.getReactor(), id);
+          this.connect(src, x.input);
         }
       }
-    );
+    });
     this.addReaction(
       [this.adder.output],
       [this.adder.output, this.writable(this.out)],
@@ -142,24 +134,16 @@ class ZenoClock extends Reactor {
     super(owner);
     console.log("Creating ZenoClock " + iteration);
     this.tick = new Timer(this, 0, 0);
-    this.addReaction(
-      [this.tick],
-      [this.tick],
-      function (this, tick) {
-        console.log("Tick at " + this.util.getElapsedLogicalTime());
-      }
-    );
+    this.addReaction([this.tick], [this.tick], function (this, tick) {
+      console.log("Tick at " + this.util.getElapsedLogicalTime());
+    });
     this.addReaction([this.shutdown], [], function (this) {
       console.log("Shutdown reaction of reactor " + iteration);
     });
     if (iteration < 5) {
-      this.addMutation(
-        [this.tick],
-        [this.tick],
-        function (this, tick) {
-          new ZenoClock(this.getReactor(), iteration + 1);
-        }
-      );
+      this.addMutation([this.tick], [this.tick], function (this, tick) {
+        new ZenoClock(this.getReactor(), iteration + 1);
+      });
     } else {
       this.util.requestStop();
     }

--- a/__tests__/mutations.test.ts
+++ b/__tests__/mutations.test.ts
@@ -16,7 +16,7 @@ class Source extends Reactor {
     super(parent);
     this.addReaction(
       [this.timer],
-      [this.writable(this.output]),
+      [this.writable(this.output)],
       function (this, out) {
         out.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       }
@@ -33,7 +33,7 @@ class AddOne extends Reactor {
     super(owner);
     this.addReaction(
       [this.input],
-      [this.input, this.writable(this.output]),
+      [this.input, this.writable(this.output)],
       function (this, input, output) {
         const val = input.get();
         if (val) {
@@ -106,7 +106,7 @@ class Computer extends Reactor {
     );
     this.addReaction(
       [this.adder.output],
-      [this.adder.output, this.writable(this.out]),
+      [this.adder.output, this.writable(this.out)],
       function (this, adderout, out) {
         const arr = adderout.get();
         if (arr) {

--- a/__tests__/mutations.test.ts
+++ b/__tests__/mutations.test.ts
@@ -5,7 +5,6 @@ import {
   OutPort,
   InPort,
   TimeValue,
-  Tuple
 } from "../src/core/internal";
 
 class Source extends Reactor {
@@ -16,8 +15,8 @@ class Source extends Reactor {
   constructor(parent: Reactor) {
     super(parent);
     this.addReaction(
-      new Tuple(this.timer),
-      new Tuple(this.writable(this.output)),
+      [this.timer],
+      [this.writable(this.output]),
       function (this, out) {
         out.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       }
@@ -33,8 +32,8 @@ class AddOne extends Reactor {
   constructor(owner: Reactor, id: number) {
     super(owner);
     this.addReaction(
-      new Tuple(this.input),
-      new Tuple(this.input, this.writable(this.output)),
+      [this.input],
+      [this.input, this.writable(this.output]),
       function (this, input, output) {
         const val = input.get();
         if (val) {
@@ -53,8 +52,8 @@ class Print extends Reactor {
   constructor(owner: Reactor) {
     super(owner);
     this.addReaction(
-      new Tuple(this.input),
-      new Tuple(this.input),
+      [this.input],
+      [this.input],
       function (this, input) {
         const val = input.get();
         console.log("Print reacting...");
@@ -88,8 +87,8 @@ class Computer extends Reactor {
     super(container);
     this._connect(this.in, this.adder.input);
     this.addMutation(
-      new Tuple(this.in),
-      new Tuple(this.in),
+      [this.in],
+      [this.in],
       function (this, src) {
         const vals = src.get();
         if (vals) {
@@ -106,8 +105,8 @@ class Computer extends Reactor {
       }
     );
     this.addReaction(
-      new Tuple(this.adder.output),
-      new Tuple(this.adder.output, this.writable(this.out)),
+      [this.adder.output],
+      [this.adder.output, this.writable(this.out]),
       function (this, adderout, out) {
         const arr = adderout.get();
         if (arr) {
@@ -130,7 +129,7 @@ class ScatterGather extends App {
     this._connect(this.source.output, this.compute.in);
     this._connect(this.compute.out, this.print.input);
     var self = this;
-    this.addReaction(new Tuple(this.shutdown), new Tuple(), function (this) {
+    this.addReaction([this.shutdown], [], function (this) {
       console.log(self._getPrecedenceGraph().toString());
     });
   }
@@ -144,19 +143,19 @@ class ZenoClock extends Reactor {
     console.log("Creating ZenoClock " + iteration);
     this.tick = new Timer(this, 0, 0);
     this.addReaction(
-      new Tuple(this.tick),
-      new Tuple(this.tick),
+      [this.tick],
+      [this.tick],
       function (this, tick) {
         console.log("Tick at " + this.util.getElapsedLogicalTime());
       }
     );
-    this.addReaction(new Tuple(this.shutdown), new Tuple(), function (this) {
+    this.addReaction([this.shutdown], [], function (this) {
       console.log("Shutdown reaction of reactor " + iteration);
     });
     if (iteration < 5) {
       this.addMutation(
-        new Tuple(this.tick),
-        new Tuple(this.tick),
+        [this.tick],
+        [this.tick],
         function (this, tick) {
           new ZenoClock(this.getReactor(), iteration + 1);
         }
@@ -175,7 +174,7 @@ class Zeno extends App {
 
     var self = this;
 
-    this.addReaction(new Tuple(this.shutdown), new Tuple(), function (this) {
+    this.addReaction([this.shutdown], [], function (this) {
       console.log(self._getPrecedenceGraph().toString());
     });
   }

--- a/__tests__/mutations.test.ts
+++ b/__tests__/mutations.test.ts
@@ -1,12 +1,11 @@
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
   Timer,
   OutPort,
   InPort,
-  TimeValue
+  TimeValue,
+  Tuple
 } from "../src/core/internal";
 
 class Source extends Reactor {
@@ -17,8 +16,8 @@ class Source extends Reactor {
   constructor(parent: Reactor) {
     super(parent);
     this.addReaction(
-      new Triggers(this.timer),
-      new Args(this.writable(this.output)),
+      new Tuple(this.timer),
+      new Tuple(this.writable(this.output)),
       function (this, out) {
         out.set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       }
@@ -34,8 +33,8 @@ class AddOne extends Reactor {
   constructor(owner: Reactor, id: number) {
     super(owner);
     this.addReaction(
-      new Triggers(this.input),
-      new Args(this.input, this.writable(this.output)),
+      new Tuple(this.input),
+      new Tuple(this.input, this.writable(this.output)),
       function (this, input, output) {
         const val = input.get();
         if (val) {
@@ -54,8 +53,8 @@ class Print extends Reactor {
   constructor(owner: Reactor) {
     super(owner);
     this.addReaction(
-      new Triggers(this.input),
-      new Args(this.input),
+      new Tuple(this.input),
+      new Tuple(this.input),
       function (this, input) {
         const val = input.get();
         console.log("Print reacting...");
@@ -89,8 +88,8 @@ class Computer extends Reactor {
     super(container);
     this._connect(this.in, this.adder.input);
     this.addMutation(
-      new Triggers(this.in),
-      new Args(this.in),
+      new Tuple(this.in),
+      new Tuple(this.in),
       function (this, src) {
         const vals = src.get();
         if (vals) {
@@ -107,8 +106,8 @@ class Computer extends Reactor {
       }
     );
     this.addReaction(
-      new Triggers(this.adder.output),
-      new Args(this.adder.output, this.writable(this.out)),
+      new Tuple(this.adder.output),
+      new Tuple(this.adder.output, this.writable(this.out)),
       function (this, adderout, out) {
         const arr = adderout.get();
         if (arr) {
@@ -131,7 +130,7 @@ class ScatterGather extends App {
     this._connect(this.source.output, this.compute.in);
     this._connect(this.compute.out, this.print.input);
     var self = this;
-    this.addReaction(new Triggers(this.shutdown), new Args(), function (this) {
+    this.addReaction(new Tuple(this.shutdown), new Tuple(), function (this) {
       console.log(self._getPrecedenceGraph().toString());
     });
   }
@@ -145,19 +144,19 @@ class ZenoClock extends Reactor {
     console.log("Creating ZenoClock " + iteration);
     this.tick = new Timer(this, 0, 0);
     this.addReaction(
-      new Triggers(this.tick),
-      new Args(this.tick),
+      new Tuple(this.tick),
+      new Tuple(this.tick),
       function (this, tick) {
         console.log("Tick at " + this.util.getElapsedLogicalTime());
       }
     );
-    this.addReaction(new Triggers(this.shutdown), new Args(), function (this) {
+    this.addReaction(new Tuple(this.shutdown), new Tuple(), function (this) {
       console.log("Shutdown reaction of reactor " + iteration);
     });
     if (iteration < 5) {
       this.addMutation(
-        new Triggers(this.tick),
-        new Args(this.tick),
+        new Tuple(this.tick),
+        new Tuple(this.tick),
         function (this, tick) {
           new ZenoClock(this.getReactor(), iteration + 1);
         }
@@ -176,7 +175,7 @@ class Zeno extends App {
 
     var self = this;
 
-    this.addReaction(new Triggers(this.shutdown), new Args(), function (this) {
+    this.addReaction(new Tuple(this.shutdown), new Tuple(), function (this) {
       console.log(self._getPrecedenceGraph().toString());
     });
   }

--- a/__tests__/port.errors.test.ts
+++ b/__tests__/port.errors.test.ts
@@ -1,9 +1,4 @@
-import {
-  Reactor,
-  App,
-  InPort,
-  OutPort
-} from "../src/core/internal";
+import {Reactor, App, InPort, OutPort} from "../src/core/internal";
 
 class R1 extends Reactor {
   inp = new InPort<number>(this);

--- a/__tests__/port.errors.test.ts
+++ b/__tests__/port.errors.test.ts
@@ -2,9 +2,7 @@ import {
   Reactor,
   App,
   InPort,
-  OutPort,
-  Triggers,
-  Args
+  OutPort
 } from "../src/core/internal";
 
 class R1 extends Reactor {

--- a/__tests__/reactors.errors.test.ts
+++ b/__tests__/reactors.errors.test.ts
@@ -1,8 +1,7 @@
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
+  Tuple,
   CalleePort,
   CallerPort,
   InPort,
@@ -23,8 +22,8 @@ class R extends Reactor {
     super(parent);
     this.callerp.remotePort = this.calleep;
     this.addReaction(
-      new Triggers(this.calleep),
-      new Args(),
+      new Tuple(this.calleep),
+      new Tuple(),
       function (this) {
         throw new Error("Method not implemented.");
       },
@@ -32,8 +31,8 @@ class R extends Reactor {
     );
 
     this.addReaction(
-      new Triggers(this.inp),
-      new Args(this.callerp),
+      new Tuple(this.inp),
+      new Tuple(this.callerp),
       function (this) {
         throw new Error("Method not implemented.");
       },
@@ -56,7 +55,7 @@ describe("Testing Error Cases", function () {
   it("Multiple reactions for a callee port", () => {
     var parent = new App();
     var reactor1 = new R(parent);
-    var trigger = new Triggers(reactor1.calleep);
+    var trigger = new Tuple(reactor1.calleep);
 
     /* expect(() => { reactor1.addReaction(
             trigger,
@@ -71,7 +70,7 @@ describe("Testing Error Cases", function () {
   it("Multiple triggers", function () {
     var parent = new App();
     var reactor1 = new R(parent);
-    var trigger = new Triggers(reactor1.calleep, new CalleePort(reactor1));
+    var trigger = new Tuple(reactor1.calleep, new CalleePort(reactor1));
 
     /* expect( () => { reactor1.addReaction(
             trigger,

--- a/__tests__/reactors.errors.test.ts
+++ b/__tests__/reactors.errors.test.ts
@@ -1,7 +1,6 @@
 import {
   Reactor,
   App,
-  Tuple,
   CalleePort,
   CallerPort,
   InPort,
@@ -22,8 +21,8 @@ class R extends Reactor {
     super(parent);
     this.callerp.remotePort = this.calleep;
     this.addReaction(
-      new Tuple(this.calleep),
-      new Tuple(),
+      [this.calleep],
+      [],
       function (this) {
         throw new Error("Method not implemented.");
       },
@@ -31,8 +30,8 @@ class R extends Reactor {
     );
 
     this.addReaction(
-      new Tuple(this.inp),
-      new Tuple(this.callerp),
+      [this.inp],
+      [this.callerp],
       function (this) {
         throw new Error("Method not implemented.");
       },
@@ -55,7 +54,7 @@ describe("Testing Error Cases", function () {
   it("Multiple reactions for a callee port", () => {
     var parent = new App();
     var reactor1 = new R(parent);
-    var trigger = new Tuple(reactor1.calleep);
+    var trigger = [reactor1.calleep];
 
     /* expect(() => { reactor1.addReaction(
             trigger,
@@ -70,7 +69,7 @@ describe("Testing Error Cases", function () {
   it("Multiple triggers", function () {
     var parent = new App();
     var reactor1 = new R(parent);
-    var trigger = new Tuple(reactor1.calleep, new CalleePort(reactor1));
+    var trigger = [reactor1.calleep, new CalleePort(reactor1]);
 
     /* expect( () => { reactor1.addReaction(
             trigger,

--- a/__tests__/reactors.errors.test.ts
+++ b/__tests__/reactors.errors.test.ts
@@ -5,7 +5,6 @@ import {
   Args,
   CalleePort,
   CallerPort,
-  Present,
   InPort,
   TimeUnit,
   TimeValue,

--- a/__tests__/reactors.errors.test.ts
+++ b/__tests__/reactors.errors.test.ts
@@ -69,7 +69,7 @@ describe("Testing Error Cases", function () {
   it("Multiple triggers", function () {
     var parent = new App();
     var reactor1 = new R(parent);
-    var trigger = [reactor1.calleep, new CalleePort(reactor1]);
+    var trigger = [reactor1.calleep, new CalleePort(reactor1)];
 
     /* expect( () => { reactor1.addReaction(
             trigger,

--- a/__tests__/reactors.test.ts
+++ b/__tests__/reactors.test.ts
@@ -20,7 +20,7 @@ class Starter extends Reactor {
     super(parent);
     this.addReaction(
       [this.startup],
-      [this.writable(this.out]),
+      [this.writable(this.out)],
       function (this, __out) {
         __out.set(4);
       }
@@ -42,7 +42,7 @@ class R1 extends Reactor {
     super(parent);
     this.addReaction(
       [this.in],
-      [this.in, this.writable(this.out]),
+      [this.in, this.writable(this.out)],
       function (this, __in, __out) {
         const util = this.util;
         const initialElapsedTime = util.getElapsedPhysicalTime();
@@ -155,7 +155,7 @@ class ReactorWithAction extends App {
     super(timeout, false, false, success, fail);
     this.addReaction(
       [this.t],
-      [this.schedulable(this.a]),
+      [this.schedulable(this.a)],
       function (this, a) {
         a.schedule(0, 1);
       }

--- a/__tests__/reactors.test.ts
+++ b/__tests__/reactors.test.ts
@@ -1,8 +1,7 @@
 import {
   Reactor,
   App,
-  Triggers,
-  Args,
+  Tuple,
   Timer,
   OutPort,
   InPort,
@@ -21,8 +20,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.writable(this.out)),
+      new Tuple(this.startup),
+      new Tuple(this.writable(this.out)),
       function (this, __out) {
         __out.set(4);
       }
@@ -43,8 +42,8 @@ class R1 extends Reactor {
   ) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in),
-      new Args(this.in, this.writable(this.out)),
+      new Tuple(this.in),
+      new Tuple(this.in, this.writable(this.out)),
       function (this, __in, __out) {
         const util = this.util;
         const initialElapsedTime = util.getElapsedPhysicalTime();
@@ -96,8 +95,8 @@ class R2 extends Reactor {
   ) {
     super(parent);
     this.addReaction(
-      new Triggers(this.in),
-      new Args(this.in),
+      new Tuple(this.in),
+      new Tuple(this.in),
       function (this, __in) {
         const tmp = __in.get();
         /* Do Nothing */
@@ -156,8 +155,8 @@ class ReactorWithAction extends App {
   ) {
     super(timeout, false, false, success, fail);
     this.addReaction(
-      new Triggers(this.t),
-      new Args(this.schedulable(this.a)),
+      new Tuple(this.t),
+      new Tuple(this.schedulable(this.a)),
       function (this, a) {
         a.schedule(0, 1);
       }

--- a/__tests__/reactors.test.ts
+++ b/__tests__/reactors.test.ts
@@ -153,13 +153,9 @@ class ReactorWithAction extends App {
     deadlineMiss?: () => void
   ) {
     super(timeout, false, false, success, fail);
-    this.addReaction(
-      [this.t],
-      [this.schedulable(this.a)],
-      function (this, a) {
-        a.schedule(0, 1);
-      }
-    );
+    this.addReaction([this.t], [this.schedulable(this.a)], function (this, a) {
+      a.schedule(0, 1);
+    });
   }
 }
 

--- a/__tests__/reactors.test.ts
+++ b/__tests__/reactors.test.ts
@@ -1,7 +1,6 @@
 import {
   Reactor,
   App,
-  Tuple,
   Timer,
   OutPort,
   InPort,
@@ -20,8 +19,8 @@ class Starter extends Reactor {
   constructor(parent: Reactor | null) {
     super(parent);
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.writable(this.out)),
+      [this.startup],
+      [this.writable(this.out]),
       function (this, __out) {
         __out.set(4);
       }
@@ -42,8 +41,8 @@ class R1 extends Reactor {
   ) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in),
-      new Tuple(this.in, this.writable(this.out)),
+      [this.in],
+      [this.in, this.writable(this.out]),
       function (this, __in, __out) {
         const util = this.util;
         const initialElapsedTime = util.getElapsedPhysicalTime();
@@ -95,8 +94,8 @@ class R2 extends Reactor {
   ) {
     super(parent);
     this.addReaction(
-      new Tuple(this.in),
-      new Tuple(this.in),
+      [this.in],
+      [this.in],
       function (this, __in) {
         const tmp = __in.get();
         /* Do Nothing */
@@ -155,8 +154,8 @@ class ReactorWithAction extends App {
   ) {
     super(timeout, false, false, success, fail);
     this.addReaction(
-      new Tuple(this.t),
-      new Tuple(this.schedulable(this.a)),
+      [this.t],
+      [this.schedulable(this.a]),
       function (this, a) {
         a.schedule(0, 1);
       }

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+present-unknown

--- a/src/benchmark/FacilityLocation.ts
+++ b/src/benchmark/FacilityLocation.ts
@@ -13,7 +13,6 @@ import {
   OutPort,
   InPort,
   State,
-  Tuple,
   Action,
   Reactor,
   App
@@ -197,14 +196,13 @@ export class Producer extends Reactor {
       period
     );
     this.addReaction(
-      new Tuple(this.startup, this.nextCustomer),
-      new Tuple(
-        this.schedulable(this.nextCustomer),
+      [this.startup, this.nextCustomer],
+      [this.schedulable(this.nextCustomer),
         this.numPoints,
         this.gridSize,
         this.writable(this.toConsumer),
-        this.itemsProduced
-      ),
+        this.itemsProduced]
+      ,
       function (
         this,
         nextCustomer,
@@ -260,8 +258,8 @@ export class Summary extends Reactor {
     super(parent);
 
     this.addReaction(
-      new Tuple(this.fromRootQuadrant),
-      new Tuple(this.fromRootQuadrant),
+      [this.fromRootQuadrant],
+      [this.fromRootQuadrant],
       function (this, fromRootQuadrant) {
         const msgFromRootQuadrant = fromRootQuadrant.get();
         if (msgFromRootQuadrant != null) {
@@ -298,19 +296,19 @@ export class Accumulator extends Reactor {
     super(parent);
 
     this.addReaction(
-      new Tuple(
+      [
         this.fromFirstQuadrant,
         this.fromSecondQuadrant,
         this.fromThirdQuadrant,
         this.fromFourthQuadrant
-      ),
-      new Tuple(
+      ],
+      [
         this.fromFirstQuadrant,
         this.fromSecondQuadrant,
         this.fromThirdQuadrant,
         this.fromFourthQuadrant,
         this.writable(this.toNextAccumulator)
-      ),
+      ],
       function (
         this,
         fromFirstQuadrant,
@@ -459,8 +457,8 @@ export class Quadrant extends Reactor {
 
     // Startup reaction for initialization of state variables using given parameters.
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(
+      [this.startup],
+      [
         // Parameters.
         this.boundary,
         this.initLocalFacilities,
@@ -475,7 +473,7 @@ export class Quadrant extends Reactor {
         this.supportCustomers,
         // Statie variable totalCost is initialized inside addCustomer().
         this.totalCost
-      ),
+      ],
       function (
         this,
         // Parameters.
@@ -512,8 +510,8 @@ export class Quadrant extends Reactor {
 
     // Main mutation reaction for QuadrantActor.process() of Akka implementation.
     this.addMutation(
-      new Tuple(this.fromProducer),
-      new Tuple(
+      [this.fromProducer],
+      [
         this.hasQuadrantProducer,
         this.positionRelativeToParent,
         this.boundary,
@@ -534,7 +532,7 @@ export class Quadrant extends Reactor {
         this.hasChildren,
         this.childrenBoundaries,
         this.totalCost
-      ),
+      ],
       function (
         this,
         hasQuadrantProducer,

--- a/src/benchmark/FacilityLocation.ts
+++ b/src/benchmark/FacilityLocation.ts
@@ -9,12 +9,11 @@ import {
   Log,
   TimeValue,
   Origin,
-  Args,
   Parameter,
   OutPort,
   InPort,
   State,
-  Triggers,
+  Tuple,
   Action,
   Reactor,
   App
@@ -198,8 +197,8 @@ export class Producer extends Reactor {
       period
     );
     this.addReaction(
-      new Triggers(this.startup, this.nextCustomer),
-      new Args(
+      new Tuple(this.startup, this.nextCustomer),
+      new Tuple(
         this.schedulable(this.nextCustomer),
         this.numPoints,
         this.gridSize,
@@ -261,8 +260,8 @@ export class Summary extends Reactor {
     super(parent);
 
     this.addReaction(
-      new Triggers(this.fromRootQuadrant),
-      new Args(this.fromRootQuadrant),
+      new Tuple(this.fromRootQuadrant),
+      new Tuple(this.fromRootQuadrant),
       function (this, fromRootQuadrant) {
         const msgFromRootQuadrant = fromRootQuadrant.get();
         if (msgFromRootQuadrant != null) {
@@ -299,13 +298,13 @@ export class Accumulator extends Reactor {
     super(parent);
 
     this.addReaction(
-      new Triggers(
+      new Tuple(
         this.fromFirstQuadrant,
         this.fromSecondQuadrant,
         this.fromThirdQuadrant,
         this.fromFourthQuadrant
       ),
-      new Args(
+      new Tuple(
         this.fromFirstQuadrant,
         this.fromSecondQuadrant,
         this.fromThirdQuadrant,
@@ -460,8 +459,8 @@ export class Quadrant extends Reactor {
 
     // Startup reaction for initialization of state variables using given parameters.
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(
+      new Tuple(this.startup),
+      new Tuple(
         // Parameters.
         this.boundary,
         this.initLocalFacilities,
@@ -513,8 +512,8 @@ export class Quadrant extends Reactor {
 
     // Main mutation reaction for QuadrantActor.process() of Akka implementation.
     this.addMutation(
-      new Triggers(this.fromProducer),
-      new Args(
+      new Tuple(this.fromProducer),
+      new Tuple(
         this.hasQuadrantProducer,
         this.positionRelativeToParent,
         this.boundary,

--- a/src/benchmark/FacilityLocation.ts
+++ b/src/benchmark/FacilityLocation.ts
@@ -197,12 +197,13 @@ export class Producer extends Reactor {
     );
     this.addReaction(
       [this.startup, this.nextCustomer],
-      [this.schedulable(this.nextCustomer),
+      [
+        this.schedulable(this.nextCustomer),
         this.numPoints,
         this.gridSize,
         this.writable(this.toConsumer),
-        this.itemsProduced]
-      ,
+        this.itemsProduced
+      ],
       function (
         this,
         nextCustomer,

--- a/src/benchmark/PingPong.ts
+++ b/src/benchmark/PingPong.ts
@@ -1,4 +1,4 @@
-import {type TimeValue, Tuple} from "../core/internal";
+import {type TimeValue} from "../core/internal";
 import {
   Log,
   Parameter,
@@ -21,8 +21,8 @@ export class Ping extends Reactor {
     this.count = new Parameter(count); // Parameter
     this.client = new CallerPort(this);
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.client, this.count),
+      [this.startup],
+      [this.client, this.count],
       function (
         this,
         __client: CallerPort<number, number>,
@@ -43,8 +43,8 @@ export class Ping extends Reactor {
       }
     );
     this.addReaction(
-      new Tuple(this.startup),
-      new Tuple(this.client, this.count),
+      [this.startup],
+      [this.client, this.count],
       function (
         this,
         __client: CallerPort<number, number>,
@@ -65,15 +65,15 @@ export class Pong extends Reactor {
     super(parent);
     this.server = new CalleePort(this);
     this.addReaction(
-      new Tuple(this.dummy),
-      new Tuple(this.dummy),
+      [this.dummy],
+      [this.dummy],
       function (this) {
         return undefined;
       }
     );
     this.addReaction(
-      new Tuple(this.server),
-      new Tuple(this.server),
+      [this.server],
+      [this.server],
       function (this, __server: CalleePort<number, number>) {
         // console.log("Pong!")
         const msg = __server.get();
@@ -82,8 +82,8 @@ export class Pong extends Reactor {
       }
     );
     this.addReaction(
-      new Tuple(this.dummy), // replace this with `server` and an error is thrown.
-      new Tuple(this.dummy),
+      [this.dummy], // replace this with `server` and an error is thrown.
+      [this.dummy],
       function (this) {
         return undefined;
       }

--- a/src/benchmark/PingPong.ts
+++ b/src/benchmark/PingPong.ts
@@ -64,13 +64,9 @@ export class Pong extends Reactor {
   constructor(parent: Reactor) {
     super(parent);
     this.server = new CalleePort(this);
-    this.addReaction(
-      [this.dummy],
-      [this.dummy],
-      function (this) {
-        return undefined;
-      }
-    );
+    this.addReaction([this.dummy], [this.dummy], function (this) {
+      return undefined;
+    });
     this.addReaction(
       [this.server],
       [this.server],

--- a/src/benchmark/PingPong.ts
+++ b/src/benchmark/PingPong.ts
@@ -1,11 +1,9 @@
-import type {TimeValue} from "../core/internal";
+import {type TimeValue, Tuple} from "../core/internal";
 import {
   Log,
-  Args,
   Parameter,
   CalleePort,
   CallerPort,
-  Triggers,
   Timer,
   Reactor,
   App
@@ -23,8 +21,8 @@ export class Ping extends Reactor {
     this.count = new Parameter(count); // Parameter
     this.client = new CallerPort(this);
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.client, this.count),
+      new Tuple(this.startup),
+      new Tuple(this.client, this.count),
       function (
         this,
         __client: CallerPort<number, number>,
@@ -45,8 +43,8 @@ export class Ping extends Reactor {
       }
     );
     this.addReaction(
-      new Triggers(this.startup),
-      new Args(this.client, this.count),
+      new Tuple(this.startup),
+      new Tuple(this.client, this.count),
       function (
         this,
         __client: CallerPort<number, number>,
@@ -67,15 +65,15 @@ export class Pong extends Reactor {
     super(parent);
     this.server = new CalleePort(this);
     this.addReaction(
-      new Triggers(this.dummy),
-      new Args(this.dummy),
+      new Tuple(this.dummy),
+      new Tuple(this.dummy),
       function (this) {
         return undefined;
       }
     );
     this.addReaction(
-      new Triggers(this.server),
-      new Args(this.server),
+      new Tuple(this.server),
+      new Tuple(this.server),
       function (this, __server: CalleePort<number, number>) {
         // console.log("Pong!")
         const msg = __server.get();
@@ -84,8 +82,8 @@ export class Pong extends Reactor {
       }
     );
     this.addReaction(
-      new Triggers(this.dummy), // replace this with `server` and an error is thrown.
-      new Args(this.dummy),
+      new Tuple(this.dummy), // replace this with `server` and an error is thrown.
+      new Tuple(this.dummy),
       function (this) {
         return undefined;
       }

--- a/src/benchmark/Sieve.ts
+++ b/src/benchmark/Sieve.ts
@@ -1,11 +1,9 @@
-import type {WritablePort} from "../core/internal";
+import {Tuple, WritablePort} from "../core/internal";
 import {
-  Args,
   Parameter,
   InPort,
   OutPort,
   State,
-  Triggers,
   Action,
   Reactor,
   App,
@@ -27,8 +25,8 @@ class Ramp extends Reactor {
     this.until = new Parameter(until);
     this.next = new Action<number>(this, Origin.logical, period);
     this.addReaction(
-      new Triggers(this.startup, this.next),
-      new Args(
+      new Tuple(this.startup, this.next),
+      new Tuple(
         this.schedulable(this.next),
         this.until,
         this.writable(this.value)
@@ -68,8 +66,8 @@ class Filter extends Reactor {
     this.localPrimes = new State(new Array<number>());
     this.hasChild = new State(false);
     this.addMutation(
-      new Triggers(this.inp),
-      new Args(
+      new Tuple(this.inp),
+      new Tuple(
         this.inp,
         this.writable(this.out),
         this.startPrime,

--- a/src/benchmark/Sieve.ts
+++ b/src/benchmark/Sieve.ts
@@ -1,4 +1,5 @@
-import {type WritablePort,
+import {
+  type WritablePort,
   Parameter,
   InPort,
   OutPort,
@@ -25,10 +26,7 @@ class Ramp extends Reactor {
     this.next = new Action<number>(this, Origin.logical, period);
     this.addReaction(
       [this.startup, this.next],
-        [this.schedulable(this.next),
-        this.until,
-        this.writable(this.value)]
-      ,
+      [this.schedulable(this.next), this.until, this.writable(this.value)],
       function (this, next, until, value) {
         const n = next.get();
         if (n === undefined) {
@@ -65,12 +63,13 @@ class Filter extends Reactor {
     this.hasChild = new State(false);
     this.addMutation(
       [this.inp],
-      [this.inp,
-      this.writable(this.out),
-      this.startPrime,
-      this.hasChild,
-      this.localPrimes]
-      ,
+      [
+        this.inp,
+        this.writable(this.out),
+        this.startPrime,
+        this.hasChild,
+        this.localPrimes
+      ],
       function (this, inp, out, prime, hasChild, localPrimes) {
         const p = inp.get();
         if (p !== undefined) {

--- a/src/benchmark/Sieve.ts
+++ b/src/benchmark/Sieve.ts
@@ -1,5 +1,4 @@
-import {Tuple, WritablePort} from "../core/internal";
-import {
+import {type WritablePort,
   Parameter,
   InPort,
   OutPort,
@@ -25,12 +24,11 @@ class Ramp extends Reactor {
     this.until = new Parameter(until);
     this.next = new Action<number>(this, Origin.logical, period);
     this.addReaction(
-      new Tuple(this.startup, this.next),
-      new Tuple(
-        this.schedulable(this.next),
+      [this.startup, this.next],
+        [this.schedulable(this.next),
         this.until,
-        this.writable(this.value)
-      ),
+        this.writable(this.value)]
+      ,
       function (this, next, until, value) {
         const n = next.get();
         if (n === undefined) {
@@ -66,14 +64,13 @@ class Filter extends Reactor {
     this.localPrimes = new State(new Array<number>());
     this.hasChild = new State(false);
     this.addMutation(
-      new Tuple(this.inp),
-      new Tuple(
-        this.inp,
-        this.writable(this.out),
-        this.startPrime,
-        this.hasChild,
-        this.localPrimes
-      ),
+      [this.inp],
+      [this.inp,
+      this.writable(this.out),
+      this.startPrime,
+      this.hasChild,
+      this.localPrimes]
+      ,
       function (this, inp, out, prime, hasChild, localPrimes) {
         const p = inp.get();
         if (p !== undefined) {

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -19,7 +19,7 @@ import {
 
 const defaultMIT = TimeValue.withUnits(1, TimeUnit.nsec); // FIXME
 
-export abstract class SchedulableAction<T extends Present> implements Sched<T> {
+export abstract class SchedulableAction<T> implements Sched<T> {
   abstract get(): T | undefined;
   abstract schedule(
     extraDelay: 0 | TimeValue,
@@ -37,7 +37,7 @@ export abstract class SchedulableAction<T extends Present> implements Sched<T> {
  * scheduled by a reactor by invoking the schedule function in a reaction
  * or in an asynchronous callback that has been set up in a reaction.
  */
-export class Action<T extends Present>
+export class Action<T>
   extends ScheduledTrigger<T>
   implements Read<T>
 {
@@ -70,7 +70,7 @@ export class Action<T extends Present>
   }
 
   protected scheduler = new (class<
-    T extends Present
+    T
   > extends SchedulableAction<T> {
     get(): T | undefined {
       return this.action.get();
@@ -187,26 +187,26 @@ export class Action<T extends Present>
   }
 }
 
-export class Startup extends Action<Present> {
+export class Startup extends Action<unknown> {
   // FIXME: this should not be a schedulable trigger, just a trigger
   constructor(__parent__: Reactor) {
     super(__parent__, Origin.logical);
   }
 }
 
-export class Shutdown extends Action<Present> {
+export class Shutdown extends Action<unknown> {
   constructor(__parent__: Reactor) {
     super(__parent__, Origin.logical);
   }
 }
 
-export class Dummy extends Action<Present> {
+export class Dummy extends Action<unknown> {
   constructor(__parent__: Reactor) {
     super(__parent__, Origin.logical);
   }
 }
 
-export class FederatePortAction<T extends Present> extends Action<T> {
+export class FederatePortAction<T> extends Action<T> {
   constructor(
     __parent__: Reactor,
     origin: Origin,

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,10 +1,4 @@
-import type {
-  Absent,
-  Read,
-  Sched,
-  Reactor,
-  TriggerManager
-} from "./internal";
+import type {Absent, Read, Sched, Reactor, TriggerManager} from "./internal";
 import {
   Log,
   TaggedEvent,
@@ -36,10 +30,7 @@ export abstract class SchedulableAction<T> implements Sched<T> {
  * scheduled by a reactor by invoking the schedule function in a reaction
  * or in an asynchronous callback that has been set up in a reaction.
  */
-export class Action<T>
-  extends ScheduledTrigger<T>
-  implements Read<T>
-{
+export class Action<T> extends ScheduledTrigger<T> implements Read<T> {
   readonly origin: Origin;
 
   readonly minDelay: TimeValue;
@@ -68,9 +59,7 @@ export class Action<T>
     throw Error("Unable to grant access to manager.");
   }
 
-  protected scheduler = new (class<
-    T
-  > extends SchedulableAction<T> {
+  protected scheduler = new (class<T> extends SchedulableAction<T> {
     get(): T | undefined {
       return this.action.get();
     }

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,6 +1,5 @@
 import type {
   Absent,
-  Present,
   Read,
   Sched,
   Reactor,

--- a/src/core/bank.ts
+++ b/src/core/bank.ts
@@ -2,7 +2,6 @@ import type {
   IOPort,
   MultiPort,
   Port,
-  Present,
   Reactor,
   WritableMultiPort,
   WritablePort

--- a/src/core/bank.ts
+++ b/src/core/bank.ts
@@ -104,9 +104,7 @@ export class Bank<T extends Reactor, S> {
     return result;
   }
 
-  public writable<T>(
-    ports: Array<IOPort<T>>
-  ): Array<WritablePort<T>> {
+  public writable<T>(ports: Array<IOPort<T>>): Array<WritablePort<T>> {
     if (ports.length !== this.members.length) {
       throw new Error("Length of ports does not match length of reactors.");
     }

--- a/src/core/bank.ts
+++ b/src/core/bank.ts
@@ -79,7 +79,7 @@ export class Bank<T extends Reactor, S> {
    * @param selector lambda function that takes a reactor of type T and return a port of type P
    * @returns a list of ports selected across all bank members by the given lambda
    */
-  public port<P extends Port<Present> | MultiPort<Present>>(
+  public port<P extends Port<unknown> | MultiPort<unknown>>(
     selector: (reactor: T) => P
   ): P[] {
     return this.all().reduce(
@@ -92,7 +92,7 @@ export class Bank<T extends Reactor, S> {
     return `bank(${this.members.length})`;
   }
 
-  public allWritable<T extends Present>(
+  public allWritable<T>(
     ports: Array<MultiPort<T>>
   ): Array<WritableMultiPort<T>> {
     if (ports.length !== this.members.length) {
@@ -105,7 +105,7 @@ export class Bank<T extends Reactor, S> {
     return result;
   }
 
-  public writable<T extends Present>(
+  public writable<T>(
     ports: Array<IOPort<T>>
   ): Array<WritablePort<T>> {
     if (ports.length !== this.members.length) {

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -1,8 +1,4 @@
-import type {
-  Tag,
-  ScheduledTrigger,
-  PrioritySetElement
-} from "./internal";
+import type {Tag, ScheduledTrigger, PrioritySetElement} from "./internal";
 
 /**
  * An event is caused by a timer or a scheduled action. Each event is tagged

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -11,7 +11,7 @@ import type {
  * determine the event's position with respect to other events in the event
  * queue.
  */
-export class TaggedEvent<T extends Present> implements PrioritySetElement<Tag> {
+export class TaggedEvent<T> implements PrioritySetElement<Tag> {
   /**
    * Pointer to the next element of the priority set that this event might
    * be hooked into.

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -1,7 +1,6 @@
 import type {
   Tag,
   ScheduledTrigger,
-  Present,
   PrioritySetElement
 } from "./internal";
 

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1614,11 +1614,7 @@ export class FederatedApp extends App {
 
     this.rtiClient.on(
       "timedMessage",
-      <T>(
-        destPortAction: Action<T>,
-        messageBuffer: Buffer,
-        tag: Tag
-      ) => {
+      <T>(destPortAction: Action<T>, messageBuffer: Buffer, tag: Tag) => {
         // Schedule this federate port's action.
 
         /**

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1,7 +1,7 @@
 import type {Socket, SocketConnectOpts} from "net";
 import {createConnection} from "net";
 import {EventEmitter} from "events";
-import type {Present, Action, FederateConfig} from "./internal";
+import type {Action, FederateConfig} from "./internal";
 import {
   Log,
   Tag,

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -319,7 +319,7 @@ class RTIClient extends EventEmitter {
    * @param federatePortID The federate port's ID.
    * @param federatePort The federate port's action.
    */
-  public registerFederatePortAction<T extends Present>(
+  public registerFederatePortAction<T>(
     federatePortID: number,
     federatePortAction: Action<T>
   ): void {
@@ -528,7 +528,7 @@ class RTIClient extends EventEmitter {
    * @param destPortID The port ID for the port on the destination
    * federate to which this message should be sent.
    */
-  public sendRTIMessage<T extends Present>(
+  public sendRTIMessage<T>(
     data: T,
     destFederateID: number,
     destPortID: number
@@ -567,7 +567,7 @@ class RTIClient extends EventEmitter {
    * @param time The time of the message encoded as a 64 bit little endian
    * unsigned integer in a Buffer.
    */
-  public sendRTITimedMessage<T extends Present>(
+  public sendRTITimedMessage<T>(
     data: T,
     destFederateID: number,
     destPortID: number,
@@ -1140,7 +1140,7 @@ export class FederatedApp extends App {
 
   private readonly downstreamFedIDs: number[] = [];
 
-  private readonly outputControlReactionTriggers: Array<Action<Present>> = [];
+  private readonly outputControlReactionTriggers: Array<Action<unknown>> = [];
 
   /**
    * The default value, null, indicates there is no output depending on a physical action.
@@ -1168,7 +1168,7 @@ export class FederatedApp extends App {
   }
 
   public registerOutputControlReactionTrigger(
-    outputControlReactionTrigger: Action<Present>
+    outputControlReactionTrigger: Action<unknown>
   ): void {
     this.outputControlReactionTriggers.push(outputControlReactionTrigger);
   }
@@ -1221,7 +1221,7 @@ export class FederatedApp extends App {
    * closed. FIXME: what happens in that case? Will next be called?
    * @param nextEvent
    */
-  protected _canProceed(nextEvent: TaggedEvent<Present>): boolean {
+  protected _canProceed(nextEvent: TaggedEvent<unknown>): boolean {
     let tagBarrier = new Tag(TimeValue.NEVER());
     // Set tag barrier using the tag when stop is requested but not granted yet.
     // Otherwise, set the tagBarrier using the greated TAG.
@@ -1385,7 +1385,7 @@ export class FederatedApp extends App {
    * unique among all port IDs on this federate and be a number between 0 and NUMBER_OF_PORTS - 1
    * @param federatePort The federate port's action for registration.
    */
-  public registerFederatePortAction<T extends Present>(
+  public registerFederatePortAction<T>(
     federatePortID: number,
     federatePortAction: Action<T>
   ): void {
@@ -1402,7 +1402,7 @@ export class FederatedApp extends App {
    * @param destFederateID The ID of the federate intended to receive the message.
    * @param destPortID The ID of the federate's port intended to receive the message.
    */
-  public sendRTIMessage<T extends Present>(
+  public sendRTIMessage<T>(
     msg: T,
     destFederateID: number,
     destPortID: number
@@ -1425,7 +1425,7 @@ export class FederatedApp extends App {
    * @param destPortID The ID of the FederateInPort intended to receive the message.
    * @param time The offset from the current time that the message should have.
    */
-  public sendRTITimedMessage<T extends Present>(
+  public sendRTITimedMessage<T>(
     msg: T,
     destFederateID: number,
     destPortID: number,
@@ -1598,7 +1598,7 @@ export class FederatedApp extends App {
 
     this.rtiClient.on(
       "message",
-      <T extends Present>(destPortAction: Action<T>, messageBuffer: Buffer) => {
+      <T>(destPortAction: Action<T>, messageBuffer: Buffer) => {
         // Schedule this federate port's action.
         // This message is untimed, so schedule it immediately.
         Log.debug(this, () => {
@@ -1616,7 +1616,7 @@ export class FederatedApp extends App {
 
     this.rtiClient.on(
       "timedMessage",
-      <T extends Present>(
+      <T>(
         destPortAction: Action<T>,
         messageBuffer: Buffer,
         tag: Tag

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -4,7 +4,7 @@
  */
 
 import {Reaction} from "./reaction";
-import type {Sortable} from "./types";
+import type {Sortable, Variable} from "./types";
 import {Log} from "./util";
 
 /**
@@ -456,8 +456,10 @@ export class SortablePrecedenceGraph<
 /**
  * A sortable precedence graph for reactions.
  */
-export class ReactionGraph extends SortablePrecedenceGraph<Reaction<unknown>> {
+export class ReactionGraph extends SortablePrecedenceGraph<
+  Reaction<Variable[]>
+> {
   constructor(pg?: PrecedenceGraph<unknown>) {
-    super(Reaction<unknown>, pg);
+    super(Reaction<Variable[]>, pg);
   }
 }

--- a/src/core/multiport.ts
+++ b/src/core/multiport.ts
@@ -6,7 +6,8 @@ import type {
   Runtime,
   WritablePort,
   TriggerManager,
-  Reaction
+  Reaction,
+  Variable
 } from "./internal";
 import {InPort, OutPort, Trigger, Component} from "./internal";
 import {WritableMultiPort} from "./port";
@@ -18,10 +19,7 @@ import {WritableMultiPort} from "./port";
  * @author Marten Lohstroh <marten@berkeley.edu>
  * @author Hokeun Kim <hokeun@berkeley.edu>
  */
-export abstract class MultiPort<T>
-  extends Trigger
-  implements MultiRead<T>
-{
+export abstract class MultiPort<T> extends Trigger implements MultiRead<T> {
   /**
    * Return all channels of this multiport.
    */
@@ -47,9 +45,7 @@ export abstract class MultiPort<T>
    * @param ports the ports to return the values of
    * @returns the current values of the given ports
    */
-  public static values<T>(
-    ports: Array<IOPort<T>>
-  ): Array<T | Absent> {
+  public static values<T>(ports: Array<IOPort<T>>): Array<T | Absent> {
     const values = new Array<T | Absent>(ports.length);
     for (let i = 0; i < values.length; i++) {
       values[i] = ports[i].get();
@@ -132,7 +128,7 @@ export abstract class MultiPort<T>
     }
 
     /** @inheritdoc */
-    addReaction(reaction: Reaction<unknown>): void {
+    addReaction(reaction: Reaction<Variable[]>): void {
       this.port.channels().forEach((channel) => {
         channel
           .getManager(this.getContainer()._getKey(channel))
@@ -141,7 +137,7 @@ export abstract class MultiPort<T>
     }
 
     /** @inheritdoc */
-    delReaction(reaction: Reaction<unknown>): void {
+    delReaction(reaction: Reaction<Variable[]>): void {
       this.port.channels().forEach((channel) => {
         channel.getManager(this.port._key).delReaction(reaction);
       });

--- a/src/core/multiport.ts
+++ b/src/core/multiport.ts
@@ -2,7 +2,6 @@ import type {
   Absent,
   IOPort,
   MultiRead,
-  Present,
   Reactor,
   Runtime,
   WritablePort,

--- a/src/core/multiport.ts
+++ b/src/core/multiport.ts
@@ -19,7 +19,7 @@ import {WritableMultiPort} from "./port";
  * @author Marten Lohstroh <marten@berkeley.edu>
  * @author Hokeun Kim <hokeun@berkeley.edu>
  */
-export abstract class MultiPort<T extends Present>
+export abstract class MultiPort<T>
   extends Trigger
   implements MultiRead<T>
 {
@@ -48,7 +48,7 @@ export abstract class MultiPort<T extends Present>
    * @param ports the ports to return the values of
    * @returns the current values of the given ports
    */
-  public static values<T extends Present>(
+  public static values<T>(
     ports: Array<IOPort<T>>
   ): Array<T | Absent> {
     const values = new Array<T | Absent>(ports.length);
@@ -221,7 +221,7 @@ export abstract class MultiPort<T extends Present>
  * @author Marten Lohstroh <marten@berkeley.edu>
  * @author Hokeun Kim <hokeun@berkeley.edu>
  */
-export class InMultiPort<T extends Present> extends MultiPort<T> {
+export class InMultiPort<T> extends MultiPort<T> {
   /** @inheritdoc */
   public channel(index: number): InPort<T> {
     return this._channels[index];
@@ -247,7 +247,7 @@ export class InMultiPort<T extends Present> extends MultiPort<T> {
  * @author Marten Lohstroh <marten@berkeley.edu>
  * @author Hokeun Kim <hokeun@berkeley.edu>
  */
-export class OutMultiPort<T extends Present> extends MultiPort<T> {
+export class OutMultiPort<T> extends MultiPort<T> {
   /** @inheritdoc */
   constructor(container: Reactor, width: number) {
     super(container, width);

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -11,7 +11,7 @@ import type {
 } from "./internal";
 import {Trigger, Log} from "./internal";
 
-export abstract class Port<T extends Present> extends Trigger {
+export abstract class Port<T> extends Trigger {
   protected receivers = new Set<WritablePort<T>>();
 
   protected runtime!: Runtime;
@@ -68,13 +68,13 @@ export abstract class Port<T extends Present> extends Trigger {
  * a method for retrieving the port that it wraps.
  * We have this abstract class so that we can do `instanceof` checks.
  */
-export abstract class WritablePort<T extends Present> implements ReadWrite<T> {
+export abstract class WritablePort<T> implements ReadWrite<T> {
   abstract get(): T | undefined;
   abstract set(value: T): void;
   abstract getPort(): IOPort<T>;
 }
 
-export abstract class WritableMultiPort<T extends Present>
+export abstract class WritableMultiPort<T>
   implements MultiReadWrite<T>
 {
   abstract get(index: number): T | undefined;
@@ -87,7 +87,7 @@ export abstract class WritableMultiPort<T extends Present>
 /**
  * Interface for a writable multi port, intended as a wrapper for a multi port.
  */
-interface IOPortManager<T extends Present> extends TriggerManager {
+interface IOPortManager<T> extends TriggerManager {
   // TODO (axmmisaka): Function property is better in terms of type checking
   // as tsc will check additional info; yet that additional check will cause massive issues
   // and therefore this linter rule is disabled and method signature is used.
@@ -98,7 +98,7 @@ interface IOPortManager<T extends Present> extends TriggerManager {
   delReceiver(port: WritablePort<T>): void;
 }
 
-export abstract class IOPort<T extends Present> extends Port<T> {
+export abstract class IOPort<T> extends Port<T> {
   /**
    * Return the value set to this port. Return `Absent` if the connected
    * output did not have its value set at the current logical time.
@@ -215,6 +215,6 @@ export abstract class IOPort<T extends Present> extends Port<T> {
   }
 }
 
-export class OutPort<T extends Present> extends IOPort<T> {}
+export class OutPort<T> extends IOPort<T> {}
 
-export class InPort<T extends Present> extends IOPort<T> {}
+export class InPort<T> extends IOPort<T> {}

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -6,7 +6,6 @@ import type {
   TriggerManager,
   Absent,
   MultiReadWrite,
-  Present,
   ReadWrite
 } from "./internal";
 import {Trigger, Log} from "./internal";

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -6,7 +6,8 @@ import type {
   TriggerManager,
   Absent,
   MultiReadWrite,
-  ReadWrite
+  ReadWrite,
+  Variable
 } from "./internal";
 import {Trigger, Log} from "./internal";
 
@@ -70,9 +71,7 @@ export abstract class WritablePort<T> implements ReadWrite<T> {
   abstract getPort(): IOPort<T>;
 }
 
-export abstract class WritableMultiPort<T>
-  implements MultiReadWrite<T>
-{
+export abstract class WritableMultiPort<T> implements MultiReadWrite<T> {
   abstract get(index: number): T | undefined;
   abstract set(index: number, value: T): void;
   abstract width(): number;
@@ -197,11 +196,11 @@ export abstract class IOPort<T> extends Port<T> {
       this.port.receivers.delete(port);
     }
 
-    addReaction(reaction: Reaction<unknown>): void {
+    addReaction(reaction: Reaction<Variable[]>): void {
       this.port.reactions.add(reaction);
     }
 
-    delReaction(reaction: Reaction<unknown>): void {
+    delReaction(reaction: Reaction<Variable[]>): void {
       this.port.reactions.delete(reaction);
     }
   })(this);

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -5,15 +5,15 @@ import type {
   MutationSandbox,
   Reactor,
   TimeValue,
+  Tuple,
   ArgList,
-  Args,
-  Triggers
+  Variable
 } from "./internal";
 import {Log, Timer, Tag, Startup} from "./internal";
 
 /**
  * A number that indicates a reaction's position with respect to other
- * reactions in an acyclic precendence graph.
+ * reactions in an acyclic precedence graph.
  * @see ReactionQueue
  */
 export type Priority = number;
@@ -23,9 +23,9 @@ export type Priority = number;
  * the argument list of the `react` function that that is applied to when this
  * reaction gets triggered.
  *
- * @author Marten Lohstroh (marten@berkeley.edu)
+ * @author Marten Lohstroh <marten@berkeley.edu>
  */
-export class Reaction<T>
+export class Reaction<T extends Variable[]>
   implements Sortable<Priority>, PrioritySetElement<Priority>
 {
   /**
@@ -62,8 +62,8 @@ export class Reaction<T>
   constructor(
     private readonly reactor: Reactor,
     private readonly sandbox: ReactionSandbox,
-    readonly trigs: Triggers,
-    readonly args: Args<ArgList<T>>,
+    readonly trigs: Tuple<Variable[]>,
+    readonly args: Tuple<ArgList<T>>,
     private readonly react: (...args: ArgList<T>) => void,
     private deadline?: TimeValue,
     private readonly late: (...args: ArgList<T>) => void = () => {
@@ -84,7 +84,7 @@ export class Reaction<T>
    */
   isTriggeredImmediately(): boolean {
     return (
-      this.trigs.list.filter(
+      this.trigs.elements.filter(
         (trig) =>
           trig instanceof Startup ||
           (trig instanceof Timer && trig.offset.isZero())
@@ -150,9 +150,9 @@ export class Reaction<T>
         .getLaterTag(this.deadline)
         .isSmallerThan(new Tag(this.sandbox.util.getCurrentPhysicalTime(), 0))
     ) {
-      this.late.apply(this.sandbox, this.args.tuple); // late
+      this.late.apply(this.sandbox, this.args.elements); // late
     } else {
-      this.react.apply(this.sandbox, this.args.tuple); // on time
+      this.react.apply(this.sandbox, this.args.elements); // on time
     }
   }
 
@@ -183,21 +183,21 @@ export class Reaction<T>
    */
   public toString(): string {
     return `${this.reactor._getFullyQualifiedName()}[R${this.reactor._getReactionIndex(
-      this
+      this as unknown as Reaction<Variable[]>
     )}]`;
   }
 }
 
-export class Procedure<T> extends Reaction<T> {}
+export class Procedure<T extends Variable[]> extends Reaction<T> {}
 
-export class Mutation<T> extends Reaction<T> {
+export class Mutation<T extends Variable[]> extends Reaction<T> {
   readonly parent: Reactor;
 
   constructor(
     __parent__: Reactor,
     sandbox: MutationSandbox,
-    trigs: Triggers,
-    args: Args<ArgList<T>>,
+    trigs: Tuple<Variable[]>,
+    args: Tuple<ArgList<T>>,
     react: (...args: ArgList<T>) => void,
     deadline?: TimeValue,
     late?: (...args: ArgList<T>) => void
@@ -211,7 +211,7 @@ export class Mutation<T> extends Reaction<T> {
    */
   public toString(): string {
     return `${this.parent._getFullyQualifiedName()}[M${this.parent._getReactionIndex(
-      this
+      this as unknown as Reaction<Variable[]>
     )}]`;
   }
 }

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -5,7 +5,6 @@ import type {
   MutationSandbox,
   Reactor,
   TimeValue,
-  Tuple,
   ArgList,
   Variable
 } from "./internal";
@@ -62,8 +61,8 @@ export class Reaction<T extends Variable[]>
   constructor(
     private readonly reactor: Reactor,
     private readonly sandbox: ReactionSandbox,
-    readonly trigs: Tuple<Variable[]>,
-    readonly args: Tuple<ArgList<T>>,
+    readonly trigs: Variable[],
+    readonly args: [...ArgList<T>],
     private readonly react: (...args: ArgList<T>) => void,
     private deadline?: TimeValue,
     private readonly late: (...args: ArgList<T>) => void = () => {
@@ -84,7 +83,7 @@ export class Reaction<T extends Variable[]>
    */
   isTriggeredImmediately(): boolean {
     return (
-      this.trigs.elements.filter(
+      this.trigs.filter(
         (trig) =>
           trig instanceof Startup ||
           (trig instanceof Timer && trig.offset.isZero())
@@ -150,9 +149,9 @@ export class Reaction<T extends Variable[]>
         .getLaterTag(this.deadline)
         .isSmallerThan(new Tag(this.sandbox.util.getCurrentPhysicalTime(), 0))
     ) {
-      this.late.apply(this.sandbox, this.args.elements); // late
+      this.late.apply(this.sandbox, this.args); // late
     } else {
-      this.react.apply(this.sandbox, this.args.elements); // on time
+      this.react.apply(this.sandbox, this.args); // on time
     }
   }
 
@@ -196,8 +195,8 @@ export class Mutation<T extends Variable[]> extends Reaction<T> {
   constructor(
     __parent__: Reactor,
     sandbox: MutationSandbox,
-    trigs: Tuple<Variable[]>,
-    args: Tuple<ArgList<T>>,
+    trigs: Variable[],
+    args: [...ArgList<T>],
     react: (...args: ArgList<T>) => void,
     deadline?: TimeValue,
     late?: (...args: ArgList<T>) => void

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -10,7 +10,6 @@ import type {
   Priority,
   Absent,
   ArgList,
-  Present,
   Read,
   Sched,
   Variable,
@@ -764,7 +763,7 @@ export abstract class Reactor extends Component {
 
     if (calleePorts.length > 0) {
       // This is a procedure.
-      const port = calleePorts[0] as CalleePort<Present, Present>;
+      const port = calleePorts[0] as CalleePort<unknown, unknown>;
       const procedure = new Procedure(
         this,
         this._reactionScope,
@@ -1385,11 +1384,11 @@ export abstract class Reactor extends Component {
     return ifGraph;
   }
 
-  private _findOwnCalleePorts(): Set<CalleePort<Present, Present>> {
-    const ports = new Set<CalleePort<Present, Present>>();
+  private _findOwnCalleePorts(): Set<CalleePort<unknown, unknown>> {
+    const ports = new Set<CalleePort<unknown, unknown>>();
     for (const component of this._keyChain.keys()) {
       if (component instanceof CalleePort) {
-        ports.add(component as CalleePort<Present, Present>);
+        ports.add(component as CalleePort<unknown, unknown>);
       }
     }
     return ports;

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -788,9 +788,7 @@ export abstract class Reactor extends Component {
       Log.global.warn("Deadline violation occurred!");
     }
   ): void {
-    const calleePorts = trigs.filter(
-      (trig) => trig instanceof CalleePort
-    );
+    const calleePorts = trigs.filter((trig) => trig instanceof CalleePort);
 
     if (calleePorts.length > 0) {
       // This is a procedure.

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2009,7 +2009,7 @@ export class App extends Reactor {
         this.app._endOfExecution == null ||
         !this.app._endOfExecution.isSmallerThan(e.tag)
       ) {
-        this.app._eventQ.push(e as TaggedEvent<unknown>);
+        this.app._eventQ.push(e);
       }
 
       Log.debug(this, () => `Scheduling with trigger: ${e.trigger}`);

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -10,13 +10,13 @@ import {
   type Priority,
   type Absent,
   type ArgList,
-  type Present,
   type Read,
   type Sched,
   type Variable,
   type Write,
   type TriggerManager,
   ReactionGraph,
+  Tuple,
   TimeValue,
   Tag,
   Origin,
@@ -28,9 +28,7 @@ import {
   Reaction,
   Mutation,
   Procedure,
-  Args,
   SchedulableAction,
-  Triggers,
   TaggedEvent,
   Component,
   ScheduledTrigger,
@@ -161,7 +159,7 @@ export abstract class Reactor extends Component {
    * ports, reactions, and connections.
    */
   protected _dependencyGraph = new PrecedenceGraph<
-    Port<unknown> | Reaction<any>
+    Port<unknown> | Reaction<Variable[]>
   >();
 
   /**
@@ -223,7 +221,7 @@ export abstract class Reactor extends Component {
   /**
    * The list of reactions this reactor has.
    */
-  private readonly _reactions: Array<Reaction<any>> = [];
+  private readonly _reactions: Array<Reaction<Variable[]>> = [];
 
   /**
    * Sandbox for the execution of reactions.
@@ -233,7 +231,7 @@ export abstract class Reactor extends Component {
   /**
    * The list of mutations this reactor has.
    */
-  private readonly _mutations: Array<Mutation<any>> = [];
+  private readonly _mutations: Array<Mutation<Variable[]>> = [];
 
   /**
    * Sandbox for the execution of mutations.
@@ -333,8 +331,8 @@ export abstract class Reactor extends Component {
   }
 
   private _getLast(
-    reactions: Set<Reaction<any>>
-  ): Reaction<unknown> | undefined {
+    reactions: Set<Reaction<Variable[]>>
+  ): Reaction<Variable[]> | undefined {
     let index = -1;
     const all = this._getReactionsAndMutations();
 
@@ -350,8 +348,8 @@ export abstract class Reactor extends Component {
   }
 
   private _getFirst(
-    reactions: Set<Reaction<any>>
-  ): Reaction<unknown> | undefined {
+    reactions: Set<Reaction<Variable[]>>
+  ): Reaction<Variable[]> | undefined {
     let index = -1;
     const all = this._getReactionsAndMutations();
 
@@ -431,12 +429,7 @@ export abstract class Reactor extends Component {
      * @param src
      * @param dst
      */
-    public connect<
-      A extends T,
-      R,
-      T,
-      S extends R
-    >(
+    public connect<A extends T, R, T, S extends R>(
       src: CallerPort<A, R> | IOPort<S>,
       dst: CalleePort<T, S> | IOPort<R>
     ): void {
@@ -522,13 +515,13 @@ export abstract class Reactor extends Component {
     // Pass in a reference to the reactor because the runtime object
     // is inaccessible for the top-level reactor (it is created after this constructor returns).
     const self = this as Reactor;
-    this.addMutation(new Triggers(this.shutdown), new Args(), function (this) {
+    this.addMutation(new Tuple(this.shutdown), new Tuple(), function (this) {
       self._findOwnReactors().forEach((r) => {
         r._delete();
       });
     });
 
-    // If this reactor was created at runtime, simply set the priorty of
+    // If this reactor was created at runtime, simply set the priority of
     // the default to the priority of from the last mutation of its
     // container plus one. Subsequent reactions and mutations that are added
     // will get a priority relative to this one.
@@ -556,9 +549,7 @@ export abstract class Reactor extends Component {
 
   //
 
-  public allWritable<T>(
-    port: MultiPort<T>
-  ): WritableMultiPort<T> {
+  public allWritable<T>(port: MultiPort<T>): WritableMultiPort<T> {
     return port.asWritable(this._getKey(port));
   }
 
@@ -570,11 +561,11 @@ export abstract class Reactor extends Component {
    * Return the index of the reaction given as an argument.
    * @param reaction The reaction to return the index of.
    */
-  public _getReactionIndex(reaction: Reaction<any>): number {
+  public _getReactionIndex(reaction: Reaction<Variable[]>): number {
     let index: number | undefined;
 
     if (reaction instanceof Mutation) {
-      index = this._mutations.indexOf(reaction);
+      index = this._mutations.indexOf(reaction as Mutation<Variable[]>);
     } else {
       index = this._reactions.indexOf(reaction);
     }
@@ -589,11 +580,14 @@ export abstract class Reactor extends Component {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private _recordDeps<T extends Variable[]>(reaction: Reaction<any>): void {
+  private _recordDeps<T extends Variable[]>(reaction: Reaction<T>): void {
     // Add a dependency on the previous reaction or mutation, if it exists.
     const prev = this._getLastReactionOrMutation();
     if (prev != null) {
-      this._dependencyGraph.addEdge(prev, reaction);
+      this._dependencyGraph.addEdge(
+        prev,
+        reaction as unknown as Reaction<Variable[]>
+      );
     }
 
     // FIXME: Add a dependency on the last mutation that the owner of this reactor
@@ -602,14 +596,18 @@ export abstract class Reactor extends Component {
     // that allows for a link to be updated.
 
     // Set up the triggers.
-    for (const t of reaction.trigs.list) {
+    for (const t of reaction.trigs.elements) {
       // Link the trigger to the reaction.
       if (t instanceof Trigger) {
-        t.getManager(this._getKey(t)).addReaction(reaction);
+        t.getManager(this._getKey(t)).addReaction(
+          reaction as unknown as Reaction<Variable[]>
+        );
       } else if (t instanceof Array) {
         t.forEach((trigger) => {
           if (trigger instanceof Trigger) {
-            trigger.getManager(this._getKey(trigger)).addReaction(reaction);
+            trigger
+              .getManager(this._getKey(trigger))
+              .addReaction(reaction as unknown as Reaction<Variable[]>);
           } else {
             throw new Error("Non-Trigger included in Triggers list.");
           }
@@ -618,45 +616,72 @@ export abstract class Reactor extends Component {
 
       // Also record this trigger as a dependency.
       if (t instanceof IOPort) {
-        this._dependencyGraph.addEdge(t, reaction);
+        this._dependencyGraph.addEdge(
+          t,
+          reaction as unknown as Reaction<Variable[]>
+        );
       } else if (t instanceof MultiPort) {
         t.channels().forEach((channel) => {
-          this._dependencyGraph.addEdge(channel, reaction);
+          this._dependencyGraph.addEdge(
+            channel,
+            reaction as unknown as Reaction<Variable[]>
+          );
         });
       } else if (t instanceof Array) {
         t.forEach((trigger) => {
           if (trigger instanceof IOPort) {
-            this._dependencyGraph.addEdge(trigger, reaction);
+            this._dependencyGraph.addEdge(
+              trigger,
+              reaction as unknown as Reaction<Variable[]>
+            );
           } else if (trigger instanceof MultiPort) {
             trigger.channels().forEach((channel) => {
-              this._dependencyGraph.addEdge(channel, reaction);
+              this._dependencyGraph.addEdge(
+                channel,
+                reaction as unknown as Reaction<Variable[]>
+              );
             });
           } else {
             throw new Error("Non-Port included in Triggers list.");
           }
         });
       } else {
-        Log.debug(this, () => `
-        >>>>> not a dependency: ${t}`);
+        Log.debug(
+          this,
+          () => `
+        >>>>> not a dependency: ${t}`
+        );
       }
     }
 
-    const sources = new Set<Port<any>>();
-    const effects = new Set<Port<any>>();
+    const sources = new Set<Port<unknown>>();
+    const effects = new Set<Port<unknown>>();
 
-    for (const a of reaction.args.tuple) {
+    for (const a of reaction.args.elements) {
       if (a instanceof IOPort) {
-        this._dependencyGraph.addEdge(a, reaction);
+        this._dependencyGraph.addEdge(
+          a,
+          reaction as unknown as Reaction<Variable[]>
+        );
         sources.add(a);
       } else if (a instanceof MultiPort) {
         a.channels().forEach((channel) => {
-          this._dependencyGraph.addEdge(channel, reaction);
+          this._dependencyGraph.addEdge(
+            channel,
+            reaction as unknown as Reaction<Variable[]>
+          );
           sources.add(channel);
         });
       } else if (a instanceof CalleePort) {
-        this._dependencyGraph.addEdge(reaction, a);
+        this._dependencyGraph.addEdge(
+          reaction as unknown as Reaction<Variable[]>,
+          a
+        );
       } else if (a instanceof CallerPort) {
-        this._dependencyGraph.addEdge(a, reaction);
+        this._dependencyGraph.addEdge(
+          a,
+          reaction as unknown as Reaction<Variable[]>
+        );
       }
       // Only necessary if we want to add actions to the dependency graph.
       else if (a instanceof Action) {
@@ -664,11 +689,17 @@ export abstract class Reactor extends Component {
       } else if (a instanceof SchedulableAction) {
         // antidep
       } else if (a instanceof WritablePort) {
-        this._dependencyGraph.addEdge(reaction, a.getPort());
+        this._dependencyGraph.addEdge(
+          reaction as unknown as Reaction<Variable[]>,
+          a.getPort()
+        );
         effects.add(a.getPort());
       } else if (a instanceof WritableMultiPort) {
         a.getPorts().forEach((channel) => {
-          this._dependencyGraph.addEdge(reaction, channel);
+          this._dependencyGraph.addEdge(
+            reaction as unknown as Reaction<Variable[]>,
+            channel
+          );
           effects.add(channel);
         });
       }
@@ -676,10 +707,7 @@ export abstract class Reactor extends Component {
     // Make effects dependent on sources.
     for (const effect of effects) {
       for (const source of sources) {
-        this._causalityGraph.addEdge(
-          source as Port<unknown>,
-          effect as Port<unknown>
-        );
+        this._causalityGraph.addEdge(source, effect);
       }
     }
   }
@@ -690,12 +718,12 @@ export abstract class Reactor extends Component {
    * @param reaction A reaction to find the predecessor of.
    */
   protected prevReaction(
-    reaction: Reaction<unknown>
-  ): Reaction<any> | undefined {
+    reaction: Reaction<Variable[]>
+  ): Reaction<Variable[]> | undefined {
     let index: number | undefined;
 
     if (reaction instanceof Mutation) {
-      index = this._mutations.indexOf(reaction);
+      index = this._mutations.indexOf(reaction as Mutation<Variable[]>);
       if (index !== undefined && index > 0) {
         return this._mutations[index - 1];
       }
@@ -718,12 +746,12 @@ export abstract class Reactor extends Component {
    * @param reaction A reaction to find the successor of.
    */
   protected nextReaction(
-    reaction: Reaction<unknown>
-  ): Reaction<any> | undefined {
+    reaction: Reaction<Variable[]>
+  ): Reaction<Variable[]> | undefined {
     let index: number | undefined;
 
     if (reaction instanceof Mutation) {
-      index = this._mutations.indexOf(reaction);
+      index = this._mutations.indexOf(reaction as Mutation<Variable[]>);
       if (index !== undefined && index < this._mutations.length - 1) {
         return this._mutations[index + 1];
       } else if (this._reactions.length > 0) {
@@ -752,16 +780,18 @@ export abstract class Reactor extends Component {
    * @param deadline
    * @param late
    */
-  protected addReaction<T>(
-    trigs: Triggers,
-    args: Args<ArgList<T>>,
+  protected addReaction<T extends Variable[]>(
+    trigs: Tuple<Variable[]>,
+    args: Tuple<ArgList<T>>,
     react: (this: ReactionSandbox, ...args: ArgList<T>) => void,
     deadline?: TimeValue,
     late: (this: ReactionSandbox, ...args: ArgList<T>) => void = () => {
       Log.global.warn("Deadline violation occurred!");
     }
   ): void {
-    const calleePorts = trigs.list.filter((trig) => trig instanceof CalleePort);
+    const calleePorts = trigs.elements.filter(
+      (trig) => trig instanceof CalleePort
+    );
 
     if (calleePorts.length > 0) {
       // This is a procedure.
@@ -775,7 +805,7 @@ export abstract class Reactor extends Component {
         deadline,
         late
       );
-      if (trigs.list.length > 1) {
+      if (trigs.elements.length > 1) {
         // A procedure can only have a single trigger.
         throw new Error(`Procedure "${procedure}" has multiple triggers.`);
       }
@@ -786,7 +816,7 @@ export abstract class Reactor extends Component {
       port
         .getManager(this._getKey(port))
         .setLastCaller(this._getLastReactionOrMutation());
-      this._reactions.push(procedure);
+      this._reactions.push(procedure as unknown as Procedure<Variable[]>);
       // FIXME: set priority manually if this happens at runtime.
     } else {
       // This is an ordinary reaction.
@@ -801,19 +831,19 @@ export abstract class Reactor extends Component {
       );
       // Stage it directly if it to be triggered immediately.
       if (reaction.isTriggeredImmediately()) {
-        this._runtime.stage(reaction as Reaction<unknown>);
+        this._runtime.stage(reaction as unknown as Reaction<Variable[]>);
         // FIXME: if we're already running, then we need to set the priority as well.
       }
       reaction.active = true;
       this._recordDeps(reaction);
-      this._reactions.push(reaction);
+      this._reactions.push(reaction as unknown as Reaction<Variable[]>);
       // FIXME: set priority manually if this happens at runtime.
     }
   }
 
-  protected addMutation<T>(
-    trigs: Triggers,
-    args: Args<ArgList<T>>,
+  protected addMutation<T extends Variable[]>(
+    trigs: Tuple<Variable[]>,
+    args: Tuple<ArgList<T>>,
     react: (this: MutationSandbox, ...args: ArgList<T>) => void,
     deadline?: TimeValue,
     late: (this: MutationSandbox, ...args: ArgList<T>) => void = () => {
@@ -831,11 +861,11 @@ export abstract class Reactor extends Component {
     );
     // Stage it directly if it to be triggered immediately.
     if (mutation.isTriggeredImmediately()) {
-      this._runtime.stage(mutation as unknown as Reaction<unknown>); // FIXME: types
+      this._runtime.stage(mutation as unknown as Mutation<Variable[]>);
     }
     mutation.active = true;
     this._recordDeps(mutation);
-    this._mutations.push(mutation);
+    this._mutations.push(mutation as unknown as Mutation<Variable[]>);
   }
 
   private _addHierarchicalDependencies(): void {
@@ -894,8 +924,8 @@ export abstract class Reactor extends Component {
    */
   protected _getPrecedenceGraph(
     depth = -1
-  ): PrecedenceGraph<Port<unknown> | Reaction<unknown>> {
-    const graph = new PrecedenceGraph<Port<unknown> | Reaction<unknown>>();
+  ): PrecedenceGraph<Port<unknown> | Reaction<Variable[]>> {
+    const graph = new PrecedenceGraph<Port<unknown> | Reaction<Variable[]>>();
 
     this._addHierarchicalDependencies();
     this._addRPCDependencies();
@@ -926,8 +956,8 @@ export abstract class Reactor extends Component {
   /**
    * Return a list of reactions owned by this reactor.
    */
-  protected _getReactions(): Array<Reaction<unknown>> {
-    const arr = new Array<Reaction<any>>();
+  protected _getReactions(): Array<Reaction<Variable[]>> {
+    const arr = new Array<Reaction<Variable[]>>();
     this._reactions.forEach((it) => arr.push(it));
     return arr;
   }
@@ -935,8 +965,8 @@ export abstract class Reactor extends Component {
   /**
    * Return a list of reactions and mutations owned by this reactor.
    */
-  protected _getReactionsAndMutations(): Array<Reaction<unknown>> {
-    const arr = new Array<Reaction<any>>();
+  protected _getReactionsAndMutations(): Array<Reaction<Variable[]>> {
+    const arr = new Array<Reaction<Variable[]>>();
     this._mutations.forEach((it) => arr.push(it));
     this._reactions.forEach((it) => arr.push(it));
     return arr;
@@ -946,14 +976,14 @@ export abstract class Reactor extends Component {
    * Return the last mutation of this reactor. All contained reactors
    * must have their reactions depend on this.
    */
-  protected _getLastMutation(): Mutation<any> | undefined {
+  protected _getLastMutation(): Mutation<Variable[]> | undefined {
     const len = this._mutations.length;
     if (len > 0) {
       return this._mutations[len - 1];
     }
   }
 
-  protected _getFirstReactionOrMutation(): Reaction<any> | undefined {
+  protected _getFirstReactionOrMutation(): Reaction<Variable[]> | undefined {
     if (this._mutations.length > 0) {
       return this._mutations[0];
     }
@@ -965,7 +995,7 @@ export abstract class Reactor extends Component {
   /**
    * Return the last reaction or mutation of this reactor.
    */
-  protected _getLastReactionOrMutation(): Reaction<any> | undefined {
+  protected _getLastReactionOrMutation(): Reaction<Variable[]> | undefined {
     let len = this._reactions.length;
     if (len > 0) {
       return this._reactions[len - 1];
@@ -982,8 +1012,8 @@ export abstract class Reactor extends Component {
    * The returned list is a copy of the list kept inside of the reactor,
    * so changing it will not affect this reactor.
    */
-  protected _getMutations(): Array<Reaction<unknown>> {
-    const arr = new Array<Reaction<any>>();
+  protected _getMutations(): Array<Reaction<Variable[]>> {
+    const arr = new Array<Reaction<Variable[]>>();
     this._mutations.forEach((it) => arr.push(it));
     return arr;
   }
@@ -1026,12 +1056,10 @@ export abstract class Reactor extends Component {
     return false;
   }
 
-  public canConnectCall<
-    A extends T,
-    R,
-    T,
-    S extends R
-  >(src: CallerPort<A, R>, dst: CalleePort<T, S>): boolean {
+  public canConnectCall<A extends T, R, T, S extends R>(
+    src: CallerPort<A, R>,
+    dst: CalleePort<T, S>
+  ): boolean {
     // FIXME: can we change the inheritance relationship so that we can overload?
 
     if (!this._runtime.isRunning()) {
@@ -1067,10 +1095,7 @@ export abstract class Reactor extends Component {
    * @param src The start point of a new connection.
    * @param dst The end point of a new connection.
    */
-  public canConnect<R, S extends R>(
-    src: IOPort<S>,
-    dst: IOPort<R>
-  ): boolean {
+  public canConnect<R, S extends R>(src: IOPort<S>, dst: IOPort<R>): boolean {
     // Immediate rule out trivial self loops.
     if (src === dst) {
       throw Error("Source port and destination port are the same.");
@@ -1115,7 +1140,7 @@ export abstract class Reactor extends Component {
 
       // Take the local graph and merge in all the causality interfaces
       // of contained reactors. Then:
-      const graph = new PrecedenceGraph<Port<unknown> | Reaction<unknown>>();
+      const graph = new PrecedenceGraph<Port<unknown> | Reaction<Variable[]>>();
       graph.addAll(this._dependencyGraph);
 
       for (const r of this._getOwnReactors()) {
@@ -1220,10 +1245,7 @@ export abstract class Reactor extends Component {
    * @param src The source port to connect.
    * @param dst The destination port to connect.
    */
-  protected _connect<R, S extends R>(
-    src: IOPort<S>,
-    dst: IOPort<R>
-  ): void {
+  protected _connect<R, S extends R>(src: IOPort<S>, dst: IOPort<R>): void {
     if (src === undefined || src === null) {
       throw new Error("Cannot connect unspecified source");
     }
@@ -1302,12 +1324,10 @@ export abstract class Reactor extends Component {
     }
   }
 
-  protected _connectCall<
-    A extends T,
-    R,
-    T,
-    S extends R
-  >(src: CallerPort<A, R>, dst: CalleePort<T, S>): void {
+  protected _connectCall<A extends T, R, T, S extends R>(
+    src: CallerPort<A, R>,
+    dst: CalleePort<T, S>
+  ): void {
     if (this.canConnectCall(src, dst)) {
       Log.debug(this, () => `connecting ${src} and ${dst}`);
       // Treat connections between callers and callees separately.
@@ -1319,7 +1339,7 @@ export abstract class Reactor extends Component {
       const calleeManager = dst.getManager(this._getKey(dst));
       const callerManager = src.getManager(this._getKey(src));
       const container = callerManager.getContainer();
-      const callers = new Set<Reaction<any>>();
+      const callers = new Set<Reaction<Variable[]>>();
       container._dependencyGraph.getDownstreamNeighbors(src).forEach((dep) => {
         if (dep instanceof Reaction) {
           callers.add(dep);
@@ -1351,7 +1371,6 @@ export abstract class Reactor extends Component {
    * and the dependencies between them.
    */
   protected _getCausalityInterface(): PrecedenceGraph<Port<unknown>> {
-
     const ifGraph = this._causalityGraph;
     // Find all the input and output ports that this reactor owns.
 
@@ -1361,7 +1380,7 @@ export abstract class Reactor extends Component {
 
     const search = (
       output: OutPort<unknown>,
-      nodes: Set<Port<unknown> | Reaction<unknown>>
+      nodes: Set<Port<unknown> | Reaction<Variable[]>>
     ): void => {
       for (const node of nodes) {
         if (!visited.has(node)) {
@@ -1441,10 +1460,7 @@ export abstract class Reactor extends Component {
    * @param src Source port of connection to be disconnected.
    * @param dst Destination port of connection to be disconnected. If undefined, disconnect all connections from the source port.
    */
-  protected _disconnect<R, S extends R>(
-    src: IOPort<S>,
-    dst?: IOPort<R>
-  ): void {
+  protected _disconnect<R, S extends R>(src: IOPort<S>, dst?: IOPort<R>): void {
     if (
       (!this._runtime.isRunning() && this._isInScope(src, dst)) ||
       this._runtime.isRunning()
@@ -1546,10 +1562,7 @@ interface ComponentManager {
 /**
  * A caller port sends arguments of type T and receives a response of type R.
  */
-export class CallerPort<A, R>
-  extends Port<R>
-  implements Write<A>, Read<R>
-{
+export class CallerPort<A, R> extends Port<R> implements Write<A>, Read<R> {
   public get(): R | undefined {
     if (
       this.tag?.isSimultaneousWith(this.runtime.util.getCurrentTag()) ??
@@ -1591,11 +1604,11 @@ export class CallerPort<A, R>
   protected manager: TriggerManager = new (class implements TriggerManager {
     constructor(private readonly port: CallerPort<A, R>) {}
 
-    addReaction(reaction: Reaction<unknown>): void {
+    addReaction(reaction: Reaction<Variable[]>): void {
       throw new Error("A Caller port cannot use used as a trigger.");
     }
 
-    delReaction(reaction: Reaction<unknown>): void {
+    delReaction(reaction: Reaction<Variable[]>): void {
       throw new Error("A Caller port cannot use used as a trigger.");
     }
 
@@ -1611,19 +1624,16 @@ export class CallerPort<A, R>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 interface CalleeManager<T> extends TriggerManager {
-  setLastCaller: (reaction: Reaction<unknown> | undefined) => void;
-  getLastCaller: () => Reaction<unknown> | undefined;
-  addReaction: (procedure: Procedure<unknown>) => void;
-  getProcedure: () => Procedure<any> | undefined;
+  setLastCaller: (reaction: Reaction<Variable[]> | undefined) => void;
+  getLastCaller: () => Reaction<Variable[]> | undefined;
+  addReaction: (procedure: Procedure<Variable[]>) => void;
+  getProcedure: () => Procedure<Variable[]> | undefined;
 }
 
 /**
  * A callee port receives arguments of type A and send a response of type R.
  */
-export class CalleePort<A, R>
-  extends Port<A>
-  implements Read<A>, Write<R>
-{
+export class CalleePort<A, R> extends Port<A> implements Read<A>, Write<R> {
   get(): A | undefined {
     return this.argValue;
   }
@@ -1632,9 +1642,9 @@ export class CalleePort<A, R>
 
   public argValue: A | undefined;
 
-  protected procedure: Procedure<unknown> | undefined;
+  protected procedure: Procedure<Variable[]> | undefined;
 
-  protected lastCaller: Reaction<unknown> | undefined;
+  protected lastCaller: Reaction<Variable[]> | undefined;
 
   public invoke(value: A): R | undefined {
     this.argValue = value;
@@ -1671,7 +1681,7 @@ export class CalleePort<A, R>
       return this.port._getContainer();
     }
 
-    addReaction(procedure: Reaction<unknown>): void {
+    addReaction(procedure: Reaction<Variable[]>): void {
       if (this.port.procedure !== undefined) {
         throw new Error(
           "Each callee port can trigger only a single" +
@@ -1682,19 +1692,19 @@ export class CalleePort<A, R>
       this.port.procedure = procedure;
     }
 
-    delReaction(reaction: Reaction<unknown>): void {
+    delReaction(reaction: Reaction<Variable[]>): void {
       throw new Error("Method not implemented.");
     }
 
-    setLastCaller(reaction: Reaction<unknown> | undefined): void {
+    setLastCaller(reaction: Reaction<Variable[]> | undefined): void {
       this.port.lastCaller = reaction;
     }
 
-    getProcedure(): Procedure<unknown> | undefined {
+    getProcedure(): Procedure<Variable[]> | undefined {
       return this.port.procedure;
     }
 
-    getLastCaller(): Reaction<unknown> | undefined {
+    getLastCaller(): Reaction<Variable[]> | undefined {
       return this.port.lastCaller;
     }
   })(this);
@@ -1719,24 +1729,24 @@ class EventQueue extends PrioritySet<Tag> {
 }
 
 class ReactionQueue extends PrioritySet<Priority> {
-  public push(reaction: Reaction<unknown>): void {
+  public push(reaction: Reaction<Variable[]>): void {
     super.push(reaction);
   }
 
-  public pop(): Reaction<unknown> {
-    return super.pop() as Reaction<unknown>;
+  public pop(): Reaction<Variable[]> {
+    return super.pop() as Reaction<Variable[]>;
   }
 
-  public peek(): Reaction<unknown> {
-    return super.peek() as Reaction<unknown>;
+  public peek(): Reaction<Variable[]> {
+    return super.peek() as Reaction<Variable[]>;
   }
 }
 
 export interface Runtime {
   util: UtilityFunctions;
-  stage: (reaction: Reaction<unknown>) => void;
+  stage: (reaction: Reaction<Variable[]>) => void;
   initialize: (timer: Timer) => void;
-  schedule: (e: TaggedEvent<any>) => void;
+  schedule: (e: TaggedEvent<unknown>) => void;
   delete: (r: Reactor) => void;
   isRunning: () => boolean;
 }
@@ -1806,7 +1816,7 @@ export class App extends Reactor {
   /**
    * Set of reactions to stage when this app starts executing.
    */
-  private readonly _reactionsAtStartup = new Set<Reaction<unknown>>();
+  private readonly _reactionsAtStartup = new Set<Reaction<Variable[]>>();
 
   /**
    * Set of timers to schedule when this app starts executing.
@@ -1931,7 +1941,7 @@ export class App extends Reactor {
      * Stage the given reaction for execution at the current logical time.
      * @param reaction The reaction to load onto the reaction queue.
      */
-    public stage(reaction: Reaction<unknown>): void {
+    public stage(reaction: Reaction<Variable[]>): void {
       if (this.app._active) {
         this.app._reactionQ.push(reaction);
       } else {
@@ -1992,7 +2002,7 @@ export class App extends Reactor {
      * Push an event onto the event queue.
      * @param e Tagged event to push onto the event queue.
      */
-    public schedule(e: TaggedEvent<any>): void {
+    public schedule(e: TaggedEvent<unknown>): void {
       const head = this.app._eventQ.peek();
 
       // Don't schedule events past the end of execution.
@@ -2262,7 +2272,7 @@ export class App extends Reactor {
    * Iterate over all reactions in the reaction queue and execute them.
    */
   private _react(): void {
-    let r: Reaction<unknown>;
+    let r: Reaction<Variable[]>;
     while (this._reactionQ.size() > 0) {
       try {
         r = this._reactionQ.pop();

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -16,7 +16,6 @@ import {
   type Write,
   type TriggerManager,
   ReactionGraph,
-  Tuple,
   TimeValue,
   Tag,
   Origin,
@@ -515,7 +514,7 @@ export abstract class Reactor extends Component {
     // Pass in a reference to the reactor because the runtime object
     // is inaccessible for the top-level reactor (it is created after this constructor returns).
     const self = this as Reactor;
-    this.addMutation(new Tuple(this.shutdown), new Tuple(), function (this) {
+    this.addMutation([this.shutdown], [], function (this) {
       self._findOwnReactors().forEach((r) => {
         r._delete();
       });
@@ -596,7 +595,7 @@ export abstract class Reactor extends Component {
     // that allows for a link to be updated.
 
     // Set up the triggers.
-    for (const t of reaction.trigs.elements) {
+    for (const t of reaction.trigs) {
       // Link the trigger to the reaction.
       if (t instanceof Trigger) {
         t.getManager(this._getKey(t)).addReaction(
@@ -657,7 +656,7 @@ export abstract class Reactor extends Component {
     const sources = new Set<Port<unknown>>();
     const effects = new Set<Port<unknown>>();
 
-    for (const a of reaction.args.elements) {
+    for (const a of reaction.args) {
       if (a instanceof IOPort) {
         this._dependencyGraph.addEdge(
           a,
@@ -781,15 +780,15 @@ export abstract class Reactor extends Component {
    * @param late
    */
   protected addReaction<T extends Variable[]>(
-    trigs: Tuple<Variable[]>,
-    args: Tuple<ArgList<T>>,
+    trigs: Variable[],
+    args: [...ArgList<T>],
     react: (this: ReactionSandbox, ...args: ArgList<T>) => void,
     deadline?: TimeValue,
     late: (this: ReactionSandbox, ...args: ArgList<T>) => void = () => {
       Log.global.warn("Deadline violation occurred!");
     }
   ): void {
-    const calleePorts = trigs.elements.filter(
+    const calleePorts = trigs.filter(
       (trig) => trig instanceof CalleePort
     );
 
@@ -805,7 +804,7 @@ export abstract class Reactor extends Component {
         deadline,
         late
       );
-      if (trigs.elements.length > 1) {
+      if (trigs.length > 1) {
         // A procedure can only have a single trigger.
         throw new Error(`Procedure "${procedure}" has multiple triggers.`);
       }
@@ -842,8 +841,8 @@ export abstract class Reactor extends Component {
   }
 
   protected addMutation<T extends Variable[]>(
-    trigs: Tuple<Variable[]>,
-    args: Tuple<ArgList<T>>,
+    trigs: Variable[],
+    args: [...ArgList<T>],
     react: (this: MutationSandbox, ...args: ArgList<T>) => void,
     deadline?: TimeValue,
     late: (this: MutationSandbox, ...args: ArgList<T>) => void = () => {

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -162,7 +162,7 @@ export abstract class Reactor extends Component {
    * ports, reactions, and connections.
    */
   protected _dependencyGraph = new PrecedenceGraph<
-    Port<Present> | Reaction<any>
+    Port<unknown> | Reaction<any>
   >();
 
   /**
@@ -197,7 +197,7 @@ export abstract class Reactor extends Component {
    * connection at runtime could result in a cyclic dependency, _without_
    * having to consult other reactors.
    */
-  private readonly _causalityGraph = new PrecedenceGraph<Port<Present>>();
+  private readonly _causalityGraph = new PrecedenceGraph<Port<unknown>>();
 
   /**
    * Indicates whether this reactor is active (meaning it has reacted to a
@@ -895,7 +895,7 @@ export abstract class Reactor extends Component {
    */
   protected _getPrecedenceGraph(
     depth = -1
-  ): PrecedenceGraph<Port<Present> | Reaction<unknown>> {
+  ): PrecedenceGraph<Port<unknown> | Reaction<unknown>> {
     const graph = new PrecedenceGraph<Port<unknown> | Reaction<unknown>>();
 
     this._addHierarchicalDependencies();

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -1,4 +1,4 @@
-import {Component} from "./internal";
+import {Component, Variable} from "./internal";
 
 import type {
   Reactor,
@@ -11,8 +11,8 @@ import type {
 
 export interface TriggerManager {
   getContainer: () => Reactor;
-  addReaction: (reaction: Reaction<unknown>) => void;
-  delReaction: (reaction: Reaction<unknown>) => void;
+  addReaction: (reaction: Reaction<Variable[]>) => void;
+  delReaction: (reaction: Reaction<Variable[]>) => void;
 }
 
 /**
@@ -22,7 +22,7 @@ export abstract class Trigger extends Component {
   /**
    * Reactions to trigger.
    */
-  protected reactions = new Set<Reaction<unknown>>();
+  protected reactions = new Set<Reaction<Variable[]>>();
 
   /**
    * Request the manager of this trigger. The request will only be honored
@@ -109,11 +109,11 @@ export abstract class ScheduledTrigger<T> extends Trigger {
       return this.trigger._getContainer();
     }
 
-    addReaction(reaction: Reaction<unknown>): void {
+    addReaction(reaction: Reaction<Variable[]>): void {
       this.trigger.reactions.add(reaction);
     }
 
-    delReaction(reaction: Reaction<unknown>): void {
+    delReaction(reaction: Reaction<Variable[]>): void {
       this.trigger.reactions.delete(reaction);
     }
   })(this);

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -1,13 +1,12 @@
-import {Component, Variable} from "./internal";
-
-import type {
-  Reactor,
-  Runtime,
-  Absent,
-  TaggedEvent,
-  Reaction,
-  Tag
+import {Component, type Variable,
+  type Reactor,
+  type Runtime,
+  type Absent,
+  type TaggedEvent,
+  type Reaction,
+  type Tag
 } from "./internal";
+
 
 export interface TriggerManager {
   getContainer: () => Reactor;

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -47,7 +47,7 @@ export abstract class Trigger extends Component {
 /**
  *
  */
-export abstract class ScheduledTrigger<T extends Present> extends Trigger {
+export abstract class ScheduledTrigger<T> extends Trigger {
   protected value: T | Absent = undefined;
 
   protected tag: Tag | undefined;

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -4,7 +4,6 @@ import type {
   Reactor,
   Runtime,
   Absent,
-  Present,
   TaggedEvent,
   Reaction,
   Tag

--- a/src/core/trigger.ts
+++ b/src/core/trigger.ts
@@ -1,4 +1,6 @@
-import {Component, type Variable,
+import {
+  Component,
+  type Variable,
   type Reactor,
   type Runtime,
   type Absent,
@@ -6,7 +8,6 @@ import {Component, type Variable,
   type Reaction,
   type Tag
 } from "./internal";
-
 
 export interface TriggerManager {
   getContainer: () => Reactor;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,14 +77,6 @@ export type Absent = undefined;
  */
 export type ArgList<T> = T extends Variable[] ? T : never;
 
-export class Tuple<T extends Variable[]> {
-  elements: T;
-
-  constructor(...args: T) {
-    this.elements = args;
-  }
-}
-
 export interface Sortable<P> {
   setPriority: (priority: P) => void;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-import type {Tag, TimeValue, Trigger} from "./internal";
+import type {Tag, TimeValue} from "./internal";
 
 /**
  * A variable can be read, written to, or scheduled. Variables may be passed to

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -79,18 +79,6 @@ export type ArgList<T> = T extends Variable[] ? T : never;
 
 export type ParmList<T> = T extends any[] ? T : never;
 
-/**
- * Type for data exchanged between ports.
- */
-export type Present =
-  | number
-  | bigint
-  | string
-  | boolean
-  | symbol
-  | object
-  | null;
-
 export class Args<T extends Variable[]> {
   tuple: T;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,24 +77,11 @@ export type Absent = undefined;
  */
 export type ArgList<T> = T extends Variable[] ? T : never;
 
-export type ParmList<T> = T extends any[] ? T : never;
-
-export class Args<T extends Variable[]> {
-  tuple: T;
+export class Tuple<T extends Variable[]> {
+  elements: T;
 
   constructor(...args: T) {
-    this.tuple = args;
-  }
-}
-
-export class Triggers {
-  list: Array<Trigger | Trigger[]>;
-
-  constructor(
-    trigger: Trigger | Trigger[],
-    ...triggers: Array<Trigger | Trigger[]>
-  ) {
-    this.list = triggers.concat(trigger);
+    this.elements = args;
   }
 }
 

--- a/src/share/Logger.ts
+++ b/src/share/Logger.ts
@@ -1,4 +1,4 @@
-import {type Read, type ReactionSandbox, Tuple} from "../core/internal";
+import {type Read, type ReactionSandbox} from "../core/internal";
 import {Reactor, InPort, State} from "../core/internal";
 
 function print(
@@ -29,8 +29,8 @@ export class Logger extends Reactor {
   constructor(parent: Reactor, expected: unknown) {
     super(parent);
     this.addReaction(
-      new Tuple(this.i),
-      new Tuple(this.i, new State(expected)),
+      [this.i],
+      [this.i, new State(expected)],
       print
     );
   }

--- a/src/share/Logger.ts
+++ b/src/share/Logger.ts
@@ -1,5 +1,5 @@
-import type {Read, ReactionSandbox} from "../core/internal";
-import {Reactor, Triggers, Args, InPort, State} from "../core/internal";
+import {type Read, type ReactionSandbox, Tuple} from "../core/internal";
+import {Reactor, InPort, State} from "../core/internal";
 
 function print(
   this: ReactionSandbox,
@@ -29,8 +29,8 @@ export class Logger extends Reactor {
   constructor(parent: Reactor, expected: unknown) {
     super(parent);
     this.addReaction(
-      new Triggers(this.i),
-      new Args(this.i, new State(expected)),
+      new Tuple(this.i),
+      new Tuple(this.i, new State(expected)),
       print
     );
   }

--- a/src/share/Logger.ts
+++ b/src/share/Logger.ts
@@ -1,4 +1,4 @@
-import type {Read, Present, ReactionSandbox} from "../core/internal";
+import type {Read, ReactionSandbox} from "../core/internal";
 import {Reactor, Triggers, Args, InPort, State} from "../core/internal";
 
 function print(
@@ -26,7 +26,7 @@ function print(
 export class Logger extends Reactor {
   i = new InPort(this);
 
-  constructor(parent: Reactor, expected: Present) {
+  constructor(parent: Reactor, expected: unknown) {
     super(parent);
     this.addReaction(
       new Triggers(this.i),

--- a/src/share/Logger.ts
+++ b/src/share/Logger.ts
@@ -28,10 +28,6 @@ export class Logger extends Reactor {
 
   constructor(parent: Reactor, expected: unknown) {
     super(parent);
-    this.addReaction(
-      [this.i],
-      [this.i, new State(expected)],
-      print
-    );
+    this.addReaction([this.i], [this.i, new State(expected)], print);
   }
 }

--- a/src/share/SingleEvent.ts
+++ b/src/share/SingleEvent.ts
@@ -21,7 +21,7 @@ function produceOutput<S>(
   console.log("Writing payload to SingleEvent's output.");
 }
 
-export class SingleEvent<T extends Present> extends Reactor {
+export class SingleEvent<T> extends Reactor {
   o: OutPort<T> = new OutPort<T>(this);
 
   t1: Timer = new Timer(this, 0, 0);

--- a/src/share/SingleEvent.ts
+++ b/src/share/SingleEvent.ts
@@ -2,7 +2,6 @@ import {
   type Write,
   type ReactionSandbox,
   type Parameter,
-  Tuple,
   Reactor,
   Timer,
   OutPort
@@ -31,8 +30,8 @@ export class SingleEvent<T> extends Reactor {
   constructor(parent: Reactor, private readonly payload: Parameter<T>) {
     super(parent);
     this.addReaction(
-      new Tuple(this.t1),
-      new Tuple(this.writable(this.o), this.payload),
+      [this.t1],
+      [this.writable(this.o), this.payload],
       produceOutput
     );
   }

--- a/src/share/SingleEvent.ts
+++ b/src/share/SingleEvent.ts
@@ -1,9 +1,12 @@
-import type {
-  Write,
-  ReactionSandbox,
-  Parameter
+import {
+  type Write,
+  type ReactionSandbox,
+  type Parameter,
+  Tuple,
+  Reactor,
+  Timer,
+  OutPort
 } from "../core/internal";
-import {Reactor, Timer, Triggers, Args, OutPort} from "../core/internal";
 
 function produceOutput<S>(
   this: ReactionSandbox,
@@ -28,8 +31,8 @@ export class SingleEvent<T> extends Reactor {
   constructor(parent: Reactor, private readonly payload: Parameter<T>) {
     super(parent);
     this.addReaction(
-      new Triggers(this.t1),
-      new Args(this.writable(this.o), this.payload),
+      new Tuple(this.t1),
+      new Tuple(this.writable(this.o), this.payload),
       produceOutput
     );
   }

--- a/src/share/SingleEvent.ts
+++ b/src/share/SingleEvent.ts
@@ -1,7 +1,6 @@
 import type {
   Write,
   ReactionSandbox,
-  Present,
   Parameter
 } from "../core/internal";
 import {Reactor, Timer, Triggers, Args, OutPort} from "../core/internal";


### PR DESCRIPTION
See https://github.com/lf-lang/reactor-ts/issues/167

TODOs:
- [x] Make accompanying lingua-franca PR (https://github.com/lf-lang/lingua-franca/pull/1857) in that eliminates `null`
- [ ] ~~Change `null` to be `{} satisfies Record<string, never>`, check https://github.com/lf-lang/reactor-ts/tree/axmmisaka/remove-present-replace-unknown~~
- [ ] ~~Enforce `null` check~~

For reference:
> I discovered what happened; such a type gymnastics moment
> It is because typescript will infer `T extends unknown` to be `null` and it is still valid;
> If we remove `Present` and still want to check against `null`, we make all `T` to be `T extends NonNullable<unknown>`
> Or, we can just define `Present` as such...... (i.e. `type Present = NonNullable<unknown>`)?
> 
> But I don't think checking is entirely necessary, considering all tests are passing...... And we might be checking null already somewhere in the code possibly?