### PR TITLE
Refactor graph package (addresses #166)

### DIFF
--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -64,7 +64,7 @@ describe("Manually constructed simple precedence graphs", () => {
   graph.addNode(nodes[0]);
 
   it("graph equality", () => {
-    expect([...graph.nodes()]).toEqual(nodes);
+    expect([...graph.getNodes()]).toEqual(nodes);
   });
 });
 
@@ -142,7 +142,8 @@ describe("Manually constructed precedence graphs", () => {
 
   it("add node 7, make 3 dependent on it", () => {
     graph.addNode(nodes[6]);
-    graph.addEdges(nodes[2], new Set([nodes[6], nodes[3]]));
+    graph.addEdge(nodes[2], nodes[6]);
+    graph.addEdge(nodes[2], nodes[3]);
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(4); // E
     Log.global.debug(graph.toString());

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -1,4 +1,4 @@
-import type {Priority, Sortable} from "../src/core/internal";
+import type {Reaction, Priority, Sortable} from "../src/core/internal";
 import {
   Reactor,
   App,
@@ -8,8 +8,7 @@ import {
   SortablePrecedenceGraph,
   PrioritySet,
   Log,
-  StringUtil,
-  Reaction
+  StringUtil
 } from "../src/core/internal";
 
 // Log.setGlobalLevel(Log.levels.DEBUG);
@@ -57,7 +56,7 @@ class CNode<T> implements Sortable<Priority> {
 }
 
 describe("Manually constructed simple precedence graphs", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>(Reaction<unknown>);
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   var reactor = new SR(new App());
 
   var nodes = reactor.getNodes();
@@ -76,7 +75,7 @@ describe("Test for corner cases", () => {
 });
 
 describe("Manually constructed precedence graphs", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>(Reaction<unknown>);
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();
@@ -205,7 +204,7 @@ describe("Manually constructed precedence graphs", () => {
 });
 
 describe("ReactionQ", () => {
-  var graph = new SortablePrecedenceGraph<Reaction<unknown>>(Reaction<unknown>);
+  var graph = new SortablePrecedenceGraph<Reaction<unknown>>();
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -1,4 +1,4 @@
-import type {Reaction, Priority, Sortable} from "../src/core/internal";
+import type {Priority, Sortable} from "../src/core/internal";
 import {
   Reactor,
   App,
@@ -8,7 +8,8 @@ import {
   SortablePrecedenceGraph,
   PrioritySet,
   Log,
-  StringUtil
+  StringUtil,
+  Reaction
 } from "../src/core/internal";
 
 // Log.setGlobalLevel(Log.levels.DEBUG);
@@ -56,7 +57,7 @@ class CNode<T> implements Sortable<Priority> {
 }
 
 describe("Manually constructed simple precedence graphs", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>(Reaction<unknown>);
   var reactor = new SR(new App());
 
   var nodes = reactor.getNodes();
@@ -69,13 +70,13 @@ describe("Manually constructed simple precedence graphs", () => {
 });
 
 describe("Test for corner cases", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>(CNode<Priority>);
   const node: Sortable<Priority> = new CNode<Priority>();
   graph.addEdge(new CNode<Priority>(), node);
 });
 
 describe("Manually constructed precedence graphs", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>(Reaction<unknown>);
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();
@@ -204,7 +205,7 @@ describe("Manually constructed precedence graphs", () => {
 });
 
 describe("ReactionQ", () => {
-  var graph = new SortablePrecedenceGraph<Reaction<unknown>>();
+  var graph = new SortablePrecedenceGraph<Reaction<unknown>>(Reaction<unknown>);
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -96,11 +96,21 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(7); // E
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`digraph G {
-            "app.R[R0]"->"app.R[R1]"->"app.R[R4]"->"app.R[R3]"->"app.R[R5]";
-            "app.R[R0]"->"app.R[R4]";
-            "app.R[R1]"->"app.R[R2]"->"app.R[R3]";
-            }`
+      StringUtil.dontIndent
+      `graph
+        0["app.R[R3]"]
+        1["app.R[R5]"]
+        2["app.R[R4]"]
+        3["app.R[R2]"]
+        4["app.R[R1]"]
+        5["app.R[R0]"]
+        1 --> 0
+        0 --> 2
+        0 --> 3
+        3 --> 4
+        2 --> 4
+        4 --> 5
+        2 --> 5`
     );
   });
 
@@ -119,11 +129,19 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(6); // E
     expect(graph.toString()).toBe(
-      `digraph G {
-"app.R[R0]"->"app.R[R1]"->"app.R[R2]"->"app.R[R3]"->"app.R[R5]";
-"app.R[R1]"->"app.R[R4]";
-"app.R[R0]"->"app.R[R4]";
-}`
+      StringUtil.dontIndent`graph
+      0["app.R[R3]"]
+      1["app.R[R5]"]
+      2["app.R[R4]"]
+      3["app.R[R2]"]
+      4["app.R[R1]"]
+      5["app.R[R0]"]
+      1 --> 0
+      0 --> 3
+      3 --> 4
+      2 --> 4
+      4 --> 5
+      2 --> 5`
     );
   });
 
@@ -133,10 +151,15 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[1]).toEqual(3); // E
     Log.global.debug(graph.toString());
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`digraph G {
-            "app.R[R2]"->"app.R[R3]"->"app.R[R5]";
-            "app.R[R0]"->"app.R[R4]";
-            }`
+      StringUtil.dontIndent`graph
+        0["app.R[R3]"]
+        1["app.R[R5]"]
+        2["app.R[R4]"]
+        3["app.R[R2]"]
+        4["app.R[R0]"]
+        1 --> 0
+        0 --> 3
+        2 --> 4`
     );
   });
 
@@ -148,11 +171,17 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[1]).toEqual(4); // E
     Log.global.debug(graph.toString());
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`digraph G {
-            "app.R[R2]"->"app.R[R3]"->"app.R[R5]";
-            "app.R[R0]"->"app.R[R4]";
-            "app.R[R2]"->"app.R[R6]";
-            }`
+      StringUtil.dontIndent`graph
+        0["app.R[R3]"]
+        1["app.R[R5]"]
+        2["app.R[R4]"]
+        3["app.R[R2]"]
+        4["app.R[R0]"]
+        5["app.R[R6]"]
+        1 --> 0
+        0 --> 3
+        5 --> 3
+        2 --> 4`
     );
   });
 

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -71,7 +71,7 @@ describe("Manually constructed simple precedence graphs", () => {
 describe("Test for corner cases", () => {
   var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   const node: Sortable<Priority> = new CNode<Priority>();
-  graph.addEdge(node, new CNode<Priority>());
+  graph.addEdge(new CNode<Priority>(), node);
 });
 
 describe("Manually constructed precedence graphs", () => {
@@ -80,13 +80,13 @@ describe("Manually constructed precedence graphs", () => {
 
   var nodes = reactor.getNodes();
 
-  graph.addEdge(nodes[3], nodes[5]);
-  graph.addEdge(nodes[4], nodes[3]);
-  graph.addEdge(nodes[2], nodes[3]);
-  graph.addEdge(nodes[1], nodes[2]);
-  graph.addEdge(nodes[1], nodes[4]);
-  graph.addEdge(nodes[0], nodes[1]);
-  graph.addEdge(nodes[0], nodes[4]);
+  graph.addEdge(nodes[5], nodes[3]);
+  graph.addEdge(nodes[3], nodes[4]);
+  graph.addEdge(nodes[3], nodes[2]);
+  graph.addEdge(nodes[2], nodes[1]);
+  graph.addEdge(nodes[4], nodes[1]);
+  graph.addEdge(nodes[1], nodes[0]);
+  graph.addEdge(nodes[4], nodes[0]);
 
   it("reaction equality", () => {
     expect(Object.is(nodes[0], nodes[1])).toBeFalsy();
@@ -125,7 +125,7 @@ describe("Manually constructed precedence graphs", () => {
   });
 
   it("remove dependency 4 -> 5", () => {
-    graph.removeEdge(nodes[4], nodes[3]);
+    graph.removeEdge(nodes[3], nodes[4]);
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(6); // E
     expect(graph.toString()).toBe(
@@ -165,8 +165,8 @@ describe("Manually constructed precedence graphs", () => {
 
   it("add node 7, make 3 dependent on it", () => {
     graph.addNode(nodes[6]);
-    graph.addEdge(nodes[2], nodes[6]);
-    graph.addEdge(nodes[2], nodes[3]);
+    graph.addEdge(nodes[6], nodes[2]);
+    graph.addEdge(nodes[3], nodes[2]);
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(4); // E
     Log.global.debug(graph.toString());
@@ -197,7 +197,7 @@ describe("Manually constructed precedence graphs", () => {
   });
 
   it("introduce a cycle", () => {
-    graph.addEdge(nodes[5], nodes[2]);
+    graph.addEdge(nodes[2], nodes[5]);
     expect(graph.updatePriorities(false)).toBeFalsy();
     Log.global.debug(graph.toString());
   });
@@ -209,13 +209,13 @@ describe("ReactionQ", () => {
 
   var nodes = reactor.getNodes();
 
-  graph.addEdge(nodes[3], nodes[5]);
-  graph.addEdge(nodes[4], nodes[3]);
-  graph.addEdge(nodes[2], nodes[3]);
-  graph.addEdge(nodes[1], nodes[2]);
-  graph.addEdge(nodes[1], nodes[4]);
-  graph.addEdge(nodes[0], nodes[1]);
-  graph.addEdge(nodes[0], nodes[4]);
+  graph.addEdge(nodes[5], nodes[3]);
+  graph.addEdge(nodes[3], nodes[4]);
+  graph.addEdge(nodes[3], nodes[2]);
+  graph.addEdge(nodes[2], nodes[1]);
+  graph.addEdge(nodes[4], nodes[1]);
+  graph.addEdge(nodes[1], nodes[0]);
+  graph.addEdge(nodes[4], nodes[0]);
   graph.updatePriorities(false);
 
   var reactionQ = new PrioritySet<Priority>();

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -5,7 +5,7 @@ import {
   Triggers,
   Args,
   InPort,
-  SortableDependencyGraph,
+  SortablePrecedenceGraph,
   PrioritySet,
   Log,
   StringUtil
@@ -56,7 +56,7 @@ class CNode<T> implements Sortable<Priority> {
 }
 
 describe("Manually constructed simple precedence graphs", () => {
-  var graph = new SortableDependencyGraph<Sortable<Priority>>();
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   var reactor = new SR(new App());
 
   var nodes = reactor.getNodes();
@@ -69,13 +69,13 @@ describe("Manually constructed simple precedence graphs", () => {
 });
 
 describe("Test for corner cases", () => {
-  var graph = new SortableDependencyGraph<Sortable<Priority>>();
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   const node: Sortable<Priority> = new CNode<Priority>();
   graph.addEdge(node, new CNode<Priority>());
 });
 
 describe("Manually constructed precedence graphs", () => {
-  var graph = new SortableDependencyGraph<Sortable<Priority>>();
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();
@@ -204,7 +204,7 @@ describe("Manually constructed precedence graphs", () => {
 });
 
 describe("ReactionQ", () => {
-  var graph = new SortableDependencyGraph<Reaction<unknown>>();
+  var graph = new SortablePrecedenceGraph<Reaction<unknown>>();
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -1,4 +1,4 @@
-import {Reaction, Priority, Sortable, ReactionGraph} from "../src/core/internal";
+import {Priority, Sortable, ReactionGraph} from "../src/core/internal";
 import {
   Reactor,
   App,

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -1,4 +1,4 @@
-import type {Reaction, Priority, Sortable} from "../src/core/internal";
+import {Reaction, Priority, Sortable, ReactionGraph} from "../src/core/internal";
 import {
   Reactor,
   App,
@@ -56,7 +56,7 @@ class CNode<T> implements Sortable<Priority> {
 }
 
 describe("Manually constructed simple precedence graphs", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
+  var graph = new ReactionGraph();
   var reactor = new SR(new App());
 
   var nodes = reactor.getNodes();
@@ -75,7 +75,7 @@ describe("Test for corner cases", () => {
 });
 
 describe("Manually constructed precedence graphs", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
+  var graph = new ReactionGraph();
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();
@@ -203,7 +203,7 @@ describe("Manually constructed precedence graphs", () => {
 });
 
 describe("ReactionQ", () => {
-  var graph = new SortablePrecedenceGraph<Reaction<unknown>>();
+  var graph = new ReactionGraph();
   var reactor = new R(new App());
 
   var nodes = reactor.getNodes();

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -96,8 +96,7 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(7); // E
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent
-      `graph
+      StringUtil.dontIndent`graph
         0["app.R[R3]"]
         1["app.R[R5]"]
         2["app.R[R4]"]

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -69,7 +69,7 @@ describe("Manually constructed simple precedence graphs", () => {
 });
 
 describe("Test for corner cases", () => {
-  var graph = new SortablePrecedenceGraph<Sortable<Priority>>(CNode<Priority>);
+  var graph = new SortablePrecedenceGraph<Sortable<Priority>>();
   const node: Sortable<Priority> = new CNode<Priority>();
   graph.addEdge(new CNode<Priority>(), node);
 });

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -39,11 +39,11 @@ d2.addNode(node2);
 d2.addEdge(node1, node2);
 
 test("test pureEffectNodes() helper function", () => {
-  expect(d2.pureEffectNodes()).toEqual(new Set([node1]));
+  expect(d2.sinkDataNodes()).toEqual(new Set([node1]));
 });
 
 test("test pureOriginNodes() helper function", () => {
-  expect(d2.pureOriginNodes()).toEqual(new Set([node2]));
+  expect(d2.sourceDataNodes()).toEqual(new Set([node2]));
 });
 
 const d3 = new DependencyGraph<number>();
@@ -136,7 +136,7 @@ const d7 = new DependencyGraph<number>();
 const d8 = new DependencyGraph<number>();
 const d9 = new DependencyGraph<number>();
 test("test dependency graph", () => {
-  expect(d7.getOriginsOfEffect(node1).size).toBe(0);
+  expect(d7.getChildren(node1).size).toBe(0);
   d7.merge(d5);
   expect(d7.size()).toStrictEqual(d5.size());
 
@@ -144,7 +144,7 @@ test("test dependency graph", () => {
   d9.addEdge(node1, node2);
   d8.merge(d9);
   expect(d8.size()).toStrictEqual(d9.size());
-  expect(d9.getEffectsOfOrigin(node2).size).toBe(1);
+  expect(d9.getParents(node2).size).toBe(1);
   d8.removeNode(node2);
   expect(d8.size()).toStrictEqual([1, 0]);
 });

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -4,6 +4,7 @@ import {
   PrecedenceGraph,
   SortablePrecedenceGraph
 } from "../src/core/graph";
+import { StringUtil } from "../src/core/strings";
 /**
  * The tests below test the functionality of the hasCycle() utility function on various
  * dependency graphs, in combination with various graph manipulation utilities
@@ -190,6 +191,25 @@ test("test the DOT representation of the dependency graph", () => {
   expect(d11.toDotString()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
   d11.addEdge(node3, node1);
   expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
+});
+
+const d13 = new PrecedenceGraph<number>();
+const d14 = new PrecedenceGraph<Object>();
+test("test the mermaid.js representation of the dependency graph", () => {
+  expect(d13.toMermaidString()).toBe('graph');
+
+  d13.addNode(node1); // { node1 }
+  expect(d13.toMermaidString()).toBe('graph\n0["1"]');
+
+  d13.addEdge(node2, node1) // { (node1 -> node2); }
+  d13.addEdge(node3, node2) // { (node1 -> node2 -> node3); }
+  expect(d13.toMermaidString()).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --> 0\n2 --> 1');
+  expect(d13.toMermaidString([[node2, node1]])).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --x 0\n2 --> 1');
+  expect(d13.toMermaidString([[node2, node1], [node3, node2]])).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --x 0\n2 --x 1');
+
+  const obj = {0: 1};
+  d14.addNode(obj);
+  expect(d14.toMermaidString()).toBe('graph\n0["0"]');
 });
 
 const sd0 = new SortablePrecedenceGraph<Sortable<number>>();

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -38,12 +38,12 @@ d2.addNode(node1);
 d2.addNode(node2);
 d2.addEdge(node1, node2);
 
-test("test sinkNodes() helper function", () => {
-  expect(d2.sinkNodes()).toEqual(new Set([node1]));
+test("test getSinkNodes() helper function", () => {
+  expect(d2.getSinkNodes()).toEqual(new Set([node1]));
 });
 
-test("test sourceNodes() helper function", () => {
-  expect(d2.sourceNodes()).toEqual(new Set([node2]));
+test("test getSourceNodes() helper function", () => {
+  expect(d2.getSourceNodes()).toEqual(new Set([node2]));
 });
 
 const d3 = new PrecedenceGraph<number>();
@@ -173,23 +173,23 @@ test("test add/remove Edges", () => {
 const d11 = new PrecedenceGraph<number>();
 const d12 = new PrecedenceGraph<Object>();
 test("test the DOT representation of the dependency graph", () => {
-  expect(d11.toDotRepresentation()).toBe("digraph G {" + "\n}");
+  expect(d11.toDotString()).toBe("digraph G {" + "\n}");
 
   d11.addNode(node1); // { node1 }
-  expect(d11.toDotRepresentation()).toBe('digraph G {\n"1";\n}');
+  expect(d11.toDotString()).toBe('digraph G {\n"1";\n}');
 
   d11.addEdge(node1, node2); // { (node1 -> node2) }
   d11.addEdge(node2, node3); // { (node1 -> node2 -> node3) }
-  expect(d11.toDotRepresentation()).toBe('digraph G {\n"1"->"2"->"3";\n}');
+  expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"3";\n}');
 
   const obj = {0: 1};
   d12.addNode(obj);
-  expect(d12.toDotRepresentation()).toBe('digraph G {\n"[object Object]";\n}');
+  expect(d12.toDotString()).toBe('digraph G {\n"[object Object]";\n}');
 
   d11.addEdge(node2, node1);
-  expect(d11.toDotRepresentation()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
+  expect(d11.toDotString()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
   d11.addEdge(node1, node3);
-  expect(d11.toDotRepresentation()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
+  expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
 });
 
 const sd0 = new SortablePrecedenceGraph<Sortable<number>>();

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -38,12 +38,12 @@ d2.addNode(node1);
 d2.addNode(node2);
 d2.addEdge(node1, node2);
 
-test("test leafNodes() helper function", () => {
-  expect(d2.leafNodes()).toEqual(new Set([node1]));
+test("test pureEffectNodes() helper function", () => {
+  expect(d2.pureEffectNodes()).toEqual(new Set([node1]));
 });
 
-test("test rootNodes() helper function", () => {
-  expect(d2.rootNodes()).toEqual(new Set([node2]));
+test("test pureOriginNodes() helper function", () => {
+  expect(d2.pureOriginNodes()).toEqual(new Set([node2]));
 });
 
 const d3 = new DependencyGraph<number>();
@@ -136,7 +136,7 @@ const d7 = new DependencyGraph<number>();
 const d8 = new DependencyGraph<number>();
 const d9 = new DependencyGraph<number>();
 test("test dependency graph", () => {
-  expect(d7.getEdges(node1).size).toBe(0);
+  expect(d7.getOriginsOfEffect(node1).size).toBe(0);
   d7.merge(d5);
   expect(d7.size()).toStrictEqual(d5.size());
 
@@ -144,7 +144,7 @@ test("test dependency graph", () => {
   d9.addEdge(node1, node2);
   d8.merge(d9);
   expect(d8.size()).toStrictEqual(d9.size());
-  expect(d9.getBackEdges(node2).size).toBe(1);
+  expect(d9.getEffectsOfOrigin(node2).size).toBe(1);
   d8.removeNode(node2);
   expect(d8.size()).toStrictEqual([1, 0]);
 });
@@ -154,13 +154,16 @@ test("test add/remove Edges", () => {
   d10.addEdge(node1, node2); // {(node1 -> node2)}
   expect(d10.size()).toStrictEqual([2, 1]);
 
-  d10.addBackEdges(node2, new Set<number>().add(node1).add(node3)); // {(node1 -> node2), (node3 -> node2)}
+  d10.addEdge(node1, node2);
+  d10.addEdge(node3, node2);
   expect(d10.size()).toStrictEqual([3, 2]);
 
-  d10.addEdges(node1, new Set<number>().add(node2).add(node3).add(node4)); // {(node1 -> node2), (node1 -> node3), (node1 -> node4), (node3 -> node2)}
+  d10.addEdge(node1, node2);
+  d10.addEdge(node1, node3);
+  d10.addEdge(node1, node4);
   expect(d10.size()).toStrictEqual([4, 4]);
 
-  d10.addEdges(node5, new Set<number>().add(node1)); // {(node1 -> node2), (node1 -> node3), (node1 -> node4), (node3 -> node2), {node5 -> node1}}
+  d10.addEdge(node5, node1);
   expect(d10.size()).toStrictEqual([5, 5]);
 
   d10.removeEdge(node1, node2); // {(node1 -> node3), (node1 -> node4), (node3 -> node2), {node5 -> node1}}
@@ -194,16 +197,16 @@ test("test for reachableOrigins function of the dependency graph", () => {
   d13.addEdge(node1, node2);
   d13.addEdge(node1, node3);
   d13.addEdge(node2, node4); // { (node1 -> node2 -> node4), (node1 -> node3) }
-  expect(d13.reachableOrigins(node1, new Set<number>(d13.nodes())).size).toBe(
+  expect(d13.reachableOrigins(node1, new Set<number>(d13.getNodes())).size).toBe(
     3
   );
-  expect(d13.reachableOrigins(node2, new Set<number>(d13.nodes())).size).toBe(
+  expect(d13.reachableOrigins(node2, new Set<number>(d13.getNodes())).size).toBe(
     1
   );
-  expect(d13.reachableOrigins(node3, new Set<number>(d13.nodes())).size).toBe(
+  expect(d13.reachableOrigins(node3, new Set<number>(d13.getNodes())).size).toBe(
     0
   );
-  expect(d13.reachableOrigins(node4, new Set<number>(d13.nodes())).size).toBe(
+  expect(d13.reachableOrigins(node4, new Set<number>(d13.getNodes())).size).toBe(
     0
   );
 });

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -173,23 +173,23 @@ test("test add/remove Edges", () => {
 const d11 = new DependencyGraph<number>();
 const d12 = new DependencyGraph<Object>();
 test("test the DOT representation of the dependency graph", () => {
-  expect(d11.toString()).toBe("digraph G {" + "\n}");
+  expect(d11.toDOTRepresentation()).toBe("digraph G {" + "\n}");
 
   d11.addNode(node1); // { node1 }
-  expect(d11.toString()).toBe('digraph G {\n"1";\n}');
+  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1";\n}');
 
   d11.addEdge(node1, node2); // { (node1 -> node2) }
   d11.addEdge(node2, node3); // { (node1 -> node2 -> node3) }
-  expect(d11.toString()).toBe('digraph G {\n"1"->"2"->"3";\n}');
+  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1"->"2"->"3";\n}');
 
   const obj = {0: 1};
   d12.addNode(obj);
-  expect(d12.toString()).toBe('digraph G {\n"[object Object]";\n}');
+  expect(d12.toDOTRepresentation()).toBe('digraph G {\n"[object Object]";\n}');
 
   d11.addEdge(node2, node1);
-  expect(d11.toString()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
+  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
   d11.addEdge(node1, node3);
-  expect(d11.toString()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
+  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
 });
 
 const d13 = new DependencyGraph<number>();

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -1,10 +1,9 @@
-import type {PrioritySetElement} from "../src/core/queue";
+import {PrioritySet, PrioritySetElement} from "../src/core/queue";
 import type { Sortable } from "../src/core/types";
 import {
   PrecedenceGraph,
-  ReactionGraph
+  SortablePrecedenceGraph
 } from "../src/core/graph";
-import { Reaction } from "../src/core/reaction";
 /**
  * The tests below test the functionality of the hasCycle() utility function on various
  * dependency graphs, in combination with various graph manipulation utilities
@@ -18,7 +17,7 @@ const node3 = 3;
 const node4 = 4;
 const node5 = 5;
 
-const d0 = new DependencyGraph<number>();
+const d0 = new PrecedenceGraph<number>();
 d0.addNode(node1);
 d0.addEdge(node1, node1);
 
@@ -39,12 +38,12 @@ d2.addNode(node1);
 d2.addNode(node2);
 d2.addEdge(node1, node2);
 
-test("test pureEffectNodes() helper function", () => {
-  expect(d2.sinkDataNodes()).toEqual(new Set([node1]));
+test("test sinkNodes() helper function", () => {
+  expect(d2.sinkNodes()).toEqual(new Set([node1]));
 });
 
-test("test pureOriginNodes() helper function", () => {
-  expect(d2.sourceDataNodes()).toEqual(new Set([node2]));
+test("test sourceNodes() helper function", () => {
+  expect(d2.sourceNodes()).toEqual(new Set([node2]));
 });
 
 const d3 = new PrecedenceGraph<number>();
@@ -137,7 +136,7 @@ const d7 = new PrecedenceGraph<number>();
 const d8 = new PrecedenceGraph<number>();
 const d9 = new PrecedenceGraph<number>();
 test("test dependency graph", () => {
-  expect(d7.getChildren(node1).size).toBe(0);
+  expect(d7.getUpstreamNodes(node1).size).toBe(0);
   d7.merge(d5);
   expect(d7.size()).toStrictEqual(d5.size());
 
@@ -145,7 +144,7 @@ test("test dependency graph", () => {
   d9.addEdge(node1, node2);
   d8.merge(d9);
   expect(d8.size()).toStrictEqual(d9.size());
-  expect(d9.getParents(node2).size).toBe(1);
+  expect(d9.getDownstreamNodes(node2).size).toBe(1);
   d8.removeNode(node2);
   expect(d8.size()).toStrictEqual([1, 0]);
 });
@@ -193,27 +192,8 @@ test("test the DOT representation of the dependency graph", () => {
   expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
 });
 
-const d13 = new PrecedenceGraph<number>();
-test("test for reachableOrigins function of the dependency graph", () => {
-  d13.addEdge(node1, node2);
-  d13.addEdge(node1, node3);
-  d13.addEdge(node2, node4); // { (node1 -> node2 -> node4), (node1 -> node3) }
-  expect(d13.reachableOrigins(node1, new Set<number>(d13.getNodes())).size).toBe(
-    3
-  );
-  expect(d13.reachableOrigins(node2, new Set<number>(d13.getNodes())).size).toBe(
-    1
-  );
-  expect(d13.reachableOrigins(node3, new Set<number>(d13.getNodes())).size).toBe(
-    0
-  );
-  expect(d13.reachableOrigins(node4, new Set<number>(d13.getNodes())).size).toBe(
-    0
-  );
-});
-
-const sd0 = new ReactionGraph();
-const sd1 = new ReactionGraph();
+const sd0 = new SortablePrecedenceGraph<Sortable<number>>();
+const sd1 = new SortablePrecedenceGraph<Sortable<number>>();
 
 class SortVariable implements Sortable<number> {
   next: PrioritySetElement<number> | undefined;

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -1,10 +1,7 @@
 import {PrioritySet, PrioritySetElement} from "../src/core/queue";
-import type { Sortable } from "../src/core/types";
-import {
-  PrecedenceGraph,
-  SortablePrecedenceGraph
-} from "../src/core/graph";
-import { StringUtil } from "../src/core/strings";
+import type {Sortable} from "../src/core/types";
+import {PrecedenceGraph, SortablePrecedenceGraph} from "../src/core/graph";
+import {StringUtil} from "../src/core/strings";
 /**
  * The tests below test the functionality of the hasCycle() utility function on various
  * dependency graphs, in combination with various graph manipulation utilities
@@ -152,7 +149,7 @@ test("test dependency graph", () => {
 
 const d10 = new PrecedenceGraph<number>();
 test("test add/remove Edges", () => {
-  d10.addEdge(node2, node1) // {(node1 -> node2);}
+  d10.addEdge(node2, node1); // {(node1 -> node2);}
   expect(d10.size()).toStrictEqual([2, 1]);
 
   d10.addEdge(node2, node1);
@@ -179,8 +176,8 @@ test("test the DOT representation of the dependency graph", () => {
   d11.addNode(node1); // { node1 }
   expect(d11.toDotString()).toBe('digraph G {\n"1";\n}');
 
-  d11.addEdge(node2, node1) // { (node1 -> node2); }
-  d11.addEdge(node3, node2) // { (node1 -> node2 -> node3); }
+  d11.addEdge(node2, node1); // { (node1 -> node2); }
+  d11.addEdge(node3, node2); // { (node1 -> node2 -> node3); }
   expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"3";\n}');
 
   const obj = {0: 1};
@@ -190,22 +187,33 @@ test("test the DOT representation of the dependency graph", () => {
   d11.addEdge(node1, node2);
   expect(d11.toDotString()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
   d11.addEdge(node3, node1);
-  expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
+  expect(d11.toDotString()).toBe(
+    'digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}'
+  );
 });
 
 const d13 = new PrecedenceGraph<number>();
 const d14 = new PrecedenceGraph<Object>();
 test("test the mermaid.js representation of the dependency graph", () => {
-  expect(d13.toMermaidString()).toBe('graph');
+  expect(d13.toMermaidString()).toBe("graph");
 
   d13.addNode(node1); // { node1 }
   expect(d13.toMermaidString()).toBe('graph\n0["1"]');
 
-  d13.addEdge(node2, node1) // { (node1 -> node2); }
-  d13.addEdge(node3, node2) // { (node1 -> node2 -> node3); }
-  expect(d13.toMermaidString()).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --> 0\n2 --> 1');
-  expect(d13.toMermaidString([[node2, node1]])).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --x 0\n2 --> 1');
-  expect(d13.toMermaidString([[node2, node1], [node3, node2]])).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --x 0\n2 --x 1');
+  d13.addEdge(node2, node1); // { (node1 -> node2); }
+  d13.addEdge(node3, node2); // { (node1 -> node2 -> node3); }
+  expect(d13.toMermaidString()).toBe(
+    'graph\n0["1"]\n1["2"]\n2["3"]\n1 --> 0\n2 --> 1'
+  );
+  expect(d13.toMermaidString([[node2, node1]])).toBe(
+    'graph\n0["1"]\n1["2"]\n2["3"]\n1 --x 0\n2 --> 1'
+  );
+  expect(
+    d13.toMermaidString([
+      [node2, node1],
+      [node3, node2]
+    ])
+  ).toBe('graph\n0["1"]\n1["2"]\n2["3"]\n1 --x 0\n2 --x 1');
 
   const obj = {0: 1};
   d14.addNode(obj);

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -136,15 +136,15 @@ const d7 = new PrecedenceGraph<number>();
 const d8 = new PrecedenceGraph<number>();
 const d9 = new PrecedenceGraph<number>();
 test("test dependency graph", () => {
-  expect(d7.getUpstream(node1).size).toBe(0);
-  d7.merge(d5);
+  expect(d7.getInNodes(node1).size).toBe(0);
+  d7.addAll(d5);
   expect(d7.size()).toStrictEqual(d5.size());
 
   d8.addNode(node1);
   d9.addEdge(node1, node2);
-  d8.merge(d9);
+  d8.addAll(d9);
   expect(d8.size()).toStrictEqual(d9.size());
-  expect(d9.getDownstream(node2).size).toBe(1);
+  expect(d9.getOutNodes(node2).size).toBe(1);
   d8.removeNode(node2);
   expect(d8.size()).toStrictEqual([1, 0]);
 });

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -136,7 +136,7 @@ const d7 = new PrecedenceGraph<number>();
 const d8 = new PrecedenceGraph<number>();
 const d9 = new PrecedenceGraph<number>();
 test("test dependency graph", () => {
-  expect(d7.getUpstreamNodes(node1).size).toBe(0);
+  expect(d7.getUpstream(node1).size).toBe(0);
   d7.merge(d5);
   expect(d7.size()).toStrictEqual(d5.size());
 
@@ -144,7 +144,7 @@ test("test dependency graph", () => {
   d9.addEdge(node1, node2);
   d8.merge(d9);
   expect(d8.size()).toStrictEqual(d9.size());
-  expect(d9.getDownstreamNodes(node2).size).toBe(1);
+  expect(d9.getDownstream(node2).size).toBe(1);
   d8.removeNode(node2);
   expect(d8.size()).toStrictEqual([1, 0]);
 });

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -36,7 +36,7 @@ test("test hasCycle utility function on no cycle", () => {
 const d2 = new PrecedenceGraph<number>();
 d2.addNode(node1);
 d2.addNode(node2);
-d2.addEdge(node1, node2);
+d2.addEdge(node2, node1);
 
 test("test getSinkNodes() helper function", () => {
   expect(d2.getSinkNodes()).toEqual(new Set([node1]));
@@ -49,8 +49,8 @@ test("test getSourceNodes() helper function", () => {
 const d3 = new PrecedenceGraph<number>();
 d3.addNode(node1);
 d3.addNode(node2);
-d3.addEdge(node1, node2);
 d3.addEdge(node2, node1);
+d3.addEdge(node1, node2);
 
 test("test hasCycle utility function on a cycle", () => {
   expect(d3.hasCycle()).toEqual(true);
@@ -65,10 +65,10 @@ d4.addNode(node1);
 d4.addNode(node2);
 d4.addNode(node3);
 d4.addNode(node4);
-d4.addEdge(node2, node1);
-d4.addEdge(node3, node2);
-d4.addEdge(node4, node3);
-d4.addEdge(node1, node4);
+d4.addEdge(node1, node2);
+d4.addEdge(node2, node3);
+d4.addEdge(node3, node4);
+d4.addEdge(node4, node1);
 
 test("test hasCycle utility function on a larger cycle", () => {
   expect(d4.hasCycle()).toEqual(true);
@@ -78,9 +78,9 @@ const d5 = new PrecedenceGraph<number>();
 d5.addNode(node1);
 d5.addNode(node2);
 d5.addNode(node3);
-d5.addEdge(node2, node1);
-d5.addEdge(node3, node2);
-d5.addEdge(node1, node3);
+d5.addEdge(node1, node2);
+d5.addEdge(node2, node3);
+d5.addEdge(node3, node1);
 
 test("test hasCycle along on mutated graph", () => {
   expect(d5.hasCycle()).toEqual(true);
@@ -90,9 +90,9 @@ const d6 = new PrecedenceGraph<number>();
 d6.addNode(node1);
 d6.addNode(node2);
 d6.addNode(node3);
-d6.addEdge(node2, node1);
-d6.addEdge(node3, node2);
-d6.addEdge(node3, node1);
+d6.addEdge(node1, node2);
+d6.addEdge(node2, node3);
+d6.addEdge(node1, node3);
 
 test("test hasCycle along on mutated graph with no cycles", () => {
   expect(d6.hasCycle()).toEqual(false);
@@ -141,7 +141,7 @@ test("test dependency graph", () => {
   expect(d7.size()).toStrictEqual(d5.size());
 
   d8.addNode(node1);
-  d9.addEdge(node1, node2);
+  d9.addEdge(node2, node1);
   d8.addAll(d9);
   expect(d8.size()).toStrictEqual(d9.size());
   expect(d9.getDownstreamNeighbors(node2).size).toBe(1);
@@ -151,22 +151,22 @@ test("test dependency graph", () => {
 
 const d10 = new PrecedenceGraph<number>();
 test("test add/remove Edges", () => {
-  d10.addEdge(node1, node2); // {(node1 -> node2)}
+  d10.addEdge(node2, node1) // {(node1 -> node2);}
   expect(d10.size()).toStrictEqual([2, 1]);
 
-  d10.addEdge(node1, node2);
-  d10.addEdge(node3, node2);
+  d10.addEdge(node2, node1);
+  d10.addEdge(node2, node3);
   expect(d10.size()).toStrictEqual([3, 2]);
 
-  d10.addEdge(node1, node2);
-  d10.addEdge(node1, node3);
-  d10.addEdge(node1, node4);
+  d10.addEdge(node2, node1);
+  d10.addEdge(node3, node1);
+  d10.addEdge(node4, node1);
   expect(d10.size()).toStrictEqual([4, 4]);
 
-  d10.addEdge(node5, node1);
+  d10.addEdge(node1, node5);
   expect(d10.size()).toStrictEqual([5, 5]);
 
-  d10.removeEdge(node1, node2); // {(node1 -> node3), (node1 -> node4), (node3 -> node2), {node5 -> node1}}
+  d10.removeEdge(node2, node1); // {(node1 -> node3), (node1 -> node4), (node3 -> node2), {node5 -> node1}}
   expect(d10.size()).toStrictEqual([5, 4]);
 });
 
@@ -178,17 +178,17 @@ test("test the DOT representation of the dependency graph", () => {
   d11.addNode(node1); // { node1 }
   expect(d11.toDotString()).toBe('digraph G {\n"1";\n}');
 
-  d11.addEdge(node1, node2); // { (node1 -> node2) }
-  d11.addEdge(node2, node3); // { (node1 -> node2 -> node3) }
+  d11.addEdge(node2, node1) // { (node1 -> node2); }
+  d11.addEdge(node3, node2) // { (node1 -> node2 -> node3); }
   expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"3";\n}');
 
   const obj = {0: 1};
   d12.addNode(obj);
   expect(d12.toDotString()).toBe('digraph G {\n"[object Object]";\n}');
 
-  d11.addEdge(node2, node1);
+  d11.addEdge(node1, node2);
   expect(d11.toDotString()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
-  d11.addEdge(node1, node3);
+  d11.addEdge(node3, node1);
   expect(d11.toDotString()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
 });
 
@@ -208,9 +208,9 @@ class SortVariable implements Sortable<number> {
 const s0 = new SortVariable(0);
 const s1 = new SortVariable(1);
 test("test sortable dependency graph", () => {
-  sd0.addEdge(s0, s1);
-  expect(sd0.updatePriorities(false, 100)).toBe(true);
   sd0.addEdge(s1, s0);
+  expect(sd0.updatePriorities(false, 100)).toBe(true);
+  sd0.addEdge(s0, s1);
   expect(sd0.updatePriorities(true, 0)).toBe(false);
   expect(sd1.updatePriorities(true, 0)).toBe(true);
 });

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -136,7 +136,7 @@ const d7 = new PrecedenceGraph<number>();
 const d8 = new PrecedenceGraph<number>();
 const d9 = new PrecedenceGraph<number>();
 test("test dependency graph", () => {
-  expect(d7.getInNodes(node1).size).toBe(0);
+  expect(d7.getUpstreamNeighbors(node1).size).toBe(0);
   d7.addAll(d5);
   expect(d7.size()).toStrictEqual(d5.size());
 
@@ -144,7 +144,7 @@ test("test dependency graph", () => {
   d9.addEdge(node1, node2);
   d8.addAll(d9);
   expect(d8.size()).toStrictEqual(d9.size());
-  expect(d9.getOutNodes(node2).size).toBe(1);
+  expect(d9.getDownstreamNeighbors(node2).size).toBe(1);
   d8.removeNode(node2);
   expect(d8.size()).toStrictEqual([1, 0]);
 });
@@ -173,23 +173,23 @@ test("test add/remove Edges", () => {
 const d11 = new PrecedenceGraph<number>();
 const d12 = new PrecedenceGraph<Object>();
 test("test the DOT representation of the dependency graph", () => {
-  expect(d11.toDOTRepresentation()).toBe("digraph G {" + "\n}");
+  expect(d11.toDotRepresentation()).toBe("digraph G {" + "\n}");
 
   d11.addNode(node1); // { node1 }
-  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1";\n}');
+  expect(d11.toDotRepresentation()).toBe('digraph G {\n"1";\n}');
 
   d11.addEdge(node1, node2); // { (node1 -> node2) }
   d11.addEdge(node2, node3); // { (node1 -> node2 -> node3) }
-  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1"->"2"->"3";\n}');
+  expect(d11.toDotRepresentation()).toBe('digraph G {\n"1"->"2"->"3";\n}');
 
   const obj = {0: 1};
   d12.addNode(obj);
-  expect(d12.toDOTRepresentation()).toBe('digraph G {\n"[object Object]";\n}');
+  expect(d12.toDotRepresentation()).toBe('digraph G {\n"[object Object]";\n}');
 
   d11.addEdge(node2, node1);
-  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
+  expect(d11.toDotRepresentation()).toBe('digraph G {\n"2"->"1"->"2"->"3";\n}');
   d11.addEdge(node1, node3);
-  expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
+  expect(d11.toDotRepresentation()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
 });
 
 const sd0 = new SortablePrecedenceGraph<Sortable<number>>();

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -1,9 +1,10 @@
-import type {PrioritySetElement, Sortable} from "../src/core/graph";
+import type {PrioritySetElement} from "../src/core/queue";
+import type { Sortable } from "../src/core/types";
 import {
-  DependencyGraph,
-  PrioritySet,
-  SortableDependencyGraph
+  PrecedenceGraph,
+  ReactionGraph
 } from "../src/core/graph";
+import { Reaction } from "../src/core/reaction";
 /**
  * The tests below test the functionality of the hasCycle() utility function on various
  * dependency graphs, in combination with various graph manipulation utilities
@@ -25,7 +26,7 @@ test("test if one node cycle is caught", () => {
   expect(d0.hasCycle()).toEqual(true);
 });
 
-const d1 = new DependencyGraph<number>();
+const d1 = new PrecedenceGraph<number>();
 d1.addNode(node1);
 d1.addNode(node2);
 
@@ -33,7 +34,7 @@ test("test hasCycle utility function on no cycle", () => {
   expect(d1.hasCycle()).toEqual(false);
 });
 
-const d2 = new DependencyGraph<number>();
+const d2 = new PrecedenceGraph<number>();
 d2.addNode(node1);
 d2.addNode(node2);
 d2.addEdge(node1, node2);
@@ -46,7 +47,7 @@ test("test pureOriginNodes() helper function", () => {
   expect(d2.sourceDataNodes()).toEqual(new Set([node2]));
 });
 
-const d3 = new DependencyGraph<number>();
+const d3 = new PrecedenceGraph<number>();
 d3.addNode(node1);
 d3.addNode(node2);
 d3.addEdge(node1, node2);
@@ -60,7 +61,7 @@ test("test number of edges", () => {
   expect(d3.size()[1]).toBe(2);
 });
 
-const d4 = new DependencyGraph<number>();
+const d4 = new PrecedenceGraph<number>();
 d4.addNode(node1);
 d4.addNode(node2);
 d4.addNode(node3);
@@ -74,7 +75,7 @@ test("test hasCycle utility function on a larger cycle", () => {
   expect(d4.hasCycle()).toEqual(true);
 });
 
-const d5 = new DependencyGraph<number>();
+const d5 = new PrecedenceGraph<number>();
 d5.addNode(node1);
 d5.addNode(node2);
 d5.addNode(node3);
@@ -86,7 +87,7 @@ test("test hasCycle along on mutated graph", () => {
   expect(d5.hasCycle()).toEqual(true);
 });
 
-const d6 = new DependencyGraph<number>();
+const d6 = new PrecedenceGraph<number>();
 d6.addNode(node1);
 d6.addNode(node2);
 d6.addNode(node3);
@@ -132,9 +133,9 @@ test("test priority set", () => {
   ps0.empty();
   expect(ps0.size()).toBe(0);
 });
-const d7 = new DependencyGraph<number>();
-const d8 = new DependencyGraph<number>();
-const d9 = new DependencyGraph<number>();
+const d7 = new PrecedenceGraph<number>();
+const d8 = new PrecedenceGraph<number>();
+const d9 = new PrecedenceGraph<number>();
 test("test dependency graph", () => {
   expect(d7.getChildren(node1).size).toBe(0);
   d7.merge(d5);
@@ -149,7 +150,7 @@ test("test dependency graph", () => {
   expect(d8.size()).toStrictEqual([1, 0]);
 });
 
-const d10 = new DependencyGraph<number>();
+const d10 = new PrecedenceGraph<number>();
 test("test add/remove Edges", () => {
   d10.addEdge(node1, node2); // {(node1 -> node2)}
   expect(d10.size()).toStrictEqual([2, 1]);
@@ -170,8 +171,8 @@ test("test add/remove Edges", () => {
   expect(d10.size()).toStrictEqual([5, 4]);
 });
 
-const d11 = new DependencyGraph<number>();
-const d12 = new DependencyGraph<Object>();
+const d11 = new PrecedenceGraph<number>();
+const d12 = new PrecedenceGraph<Object>();
 test("test the DOT representation of the dependency graph", () => {
   expect(d11.toDOTRepresentation()).toBe("digraph G {" + "\n}");
 
@@ -192,7 +193,7 @@ test("test the DOT representation of the dependency graph", () => {
   expect(d11.toDOTRepresentation()).toBe('digraph G {\n"1"->"2"->"1"->"3";\n"2"->"3";\n}');
 });
 
-const d13 = new DependencyGraph<number>();
+const d13 = new PrecedenceGraph<number>();
 test("test for reachableOrigins function of the dependency graph", () => {
   d13.addEdge(node1, node2);
   d13.addEdge(node1, node3);
@@ -211,8 +212,8 @@ test("test for reachableOrigins function of the dependency graph", () => {
   );
 });
 
-const sd0 = new SortableDependencyGraph<Sortable<number>>();
-const sd1 = new SortableDependencyGraph<Sortable<number>>();
+const sd0 = new ReactionGraph();
+const sd1 = new ReactionGraph();
 
 class SortVariable implements Sortable<number> {
   next: PrioritySetElement<number> | undefined;

--- a/__tests__/simple.ts
+++ b/__tests__/simple.ts
@@ -68,13 +68,12 @@ describe("Test names for contained reactors", () => {
 
       it("graph before connect", () => {
         expect(this._getPrecedenceGraph().toString()).toBe(
-          "digraph G {" +
-            "\n" +
-            '"myApp.x[M0]"->"myApp[M0]";' +
-            "\n" +
-            '"myApp.y[M0]"->"myApp[M0]";' +
-            "\n" +
-            "}"
+          StringUtil.dontIndent`graph
+          0["myApp.x[M0]"]
+          1["myApp[M0]"]
+          2["myApp.y[M0]"]
+          1 --> 0
+          1 --> 2`
         );
       });
 
@@ -92,23 +91,29 @@ describe("Test names for contained reactors", () => {
 
       it("graph after connect and before disconnect", () => {
         expect(this._getPrecedenceGraph().toString()).toBe(
-          StringUtil.dontIndent`digraph G {
-                "myApp.x.a"->"myApp.y.b";
-                "myApp.x[M0]"->"myApp[M0]";
-                "myApp.y[M0]"->"myApp[M0]";
-                }`
+          StringUtil.dontIndent`graph
+            0["myApp.x.a"]
+            1["myApp.y.b"]
+            2["myApp.x[M0]"]
+            3["myApp[M0]"]
+            4["myApp.y[M0]"]
+            1 --> 0
+            3 --> 2
+            3 --> 4`
         );
       });
 
       it("graph after disconnect", () => {
         this._disconnect(this.y.b, this.x.a);
         expect(this._getPrecedenceGraph().toString()).toBe(
-          StringUtil.dontIndent`digraph G {
-                "myApp.x.a";
-                "myApp.y.b";
-                "myApp.x[M0]"->"myApp[M0]";
-                "myApp.y[M0]"->"myApp[M0]";
-                }`
+          StringUtil.dontIndent`graph
+            0["myApp.x.a"]
+            1["myApp.y.b"]
+            2["myApp.x[M0]"]
+            3["myApp[M0]"]
+            4["myApp.y[M0]"]
+            3 --> 2
+            3 --> 4`
         );
       });
 

--- a/src/benchmark/FacilityLocation.ts
+++ b/src/benchmark/FacilityLocation.ts
@@ -574,7 +574,7 @@ export class Quadrant extends Reactor {
             );
           }
         };
-        const partition =  (): void => {
+        const partition = (): void => {
           // console.log(`Quadrant at ${facility.get()} - Partition is called.`)
           notifyParentOfFacility(facility.get().clone());
           maxDepthOfKnownOpenFacility.set(
@@ -628,10 +628,7 @@ export class Quadrant extends Reactor {
             toAccumulator as unknown as WritablePort<Msg>
           ).getPort();
           // Connect Accumulator's output to Quadrant's output.
-          this.connect(
-            accumulator.toNextAccumulator,
-            toAccumulatorOfQuadrant
-          );
+          this.connect(accumulator.toNextAccumulator, toAccumulatorOfQuadrant);
 
           const firstChild = new Quadrant(
             thisReactor,
@@ -648,14 +645,8 @@ export class Quadrant extends Reactor {
           const toFirstChildPort = (
             toFirstChild as unknown as WritablePort<Msg>
           ).getPort();
-          this.connect(
-            toFirstChildPort,
-            firstChild.fromProducer
-          );
-          this.connect(
-            firstChild.toAccumulator,
-            accumulator.fromFirstQuadrant
-          );
+          this.connect(toFirstChildPort, firstChild.fromProducer);
+          this.connect(firstChild.toAccumulator, accumulator.fromFirstQuadrant);
 
           const secondChild = new Quadrant(
             thisReactor,
@@ -672,10 +663,7 @@ export class Quadrant extends Reactor {
           const toSecondChildPort = (
             toSecondChild as unknown as WritablePort<Msg>
           ).getPort();
-          this.connect(
-            toSecondChildPort,
-            secondChild.fromProducer
-          );
+          this.connect(toSecondChildPort, secondChild.fromProducer);
           this.connect(
             secondChild.toAccumulator,
             accumulator.fromSecondQuadrant
@@ -696,14 +684,8 @@ export class Quadrant extends Reactor {
           const toThirdChildPort = (
             toThirdChild as unknown as WritablePort<Msg>
           ).getPort();
-          this.connect(
-            toThirdChildPort,
-            thirdChild.fromProducer
-          );
-          this.connect(
-            thirdChild.toAccumulator,
-            accumulator.fromThirdQuadrant
-          );
+          this.connect(toThirdChildPort, thirdChild.fromProducer);
+          this.connect(thirdChild.toAccumulator, accumulator.fromThirdQuadrant);
 
           const fourthChild = new Quadrant(
             thisReactor,
@@ -720,10 +702,7 @@ export class Quadrant extends Reactor {
           const toFourthChildPort = (
             toFourthChild as unknown as WritablePort<Msg>
           ).getPort();
-          this.connect(
-            toFourthChildPort,
-            fourthChild.fromProducer
-          );
+          this.connect(toFourthChildPort, fourthChild.fromProducer);
           this.connect(
             fourthChild.toAccumulator,
             accumulator.fromFourthQuadrant
@@ -792,9 +771,7 @@ export class Quadrant extends Reactor {
             }
             break;
           default:
-            console.log(
-              `Error: Recieved unknown message: ${msg?.constructor}`
-            );
+            console.log(`Error: Recieved unknown message: ${msg?.constructor}`);
             this.util.requestErrorStop();
             break;
         }

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1203,9 +1203,7 @@ export class FederatedApp extends App {
     } else {
       Log.global.debug(
         "Ignoring FederatedApp._shutdown() since EndOfExecution is already set earlier than current tag." +
-          `currentTag: ${this.util.getCurrentTag()} endTag: ${String(
-            endTag
-          )}`
+          `currentTag: ${this.util.getCurrentTag()} endTag: ${String(endTag)}`
       );
     }
   }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -134,7 +134,7 @@ export class PrecedenceGraph<T> {
    * Add an edge that denotes origin effect relationship,
    * which, in the underlying dependency graph, has direction effect->origin.
    */
-  addEdge(downstream: T, upstream: T): void {
+  addEdge(upstream: T, downstream: T): void {
     // FIXME: switch order.
     const deps = this.adjacencyMap.get(downstream);
     if (deps == null) {
@@ -154,7 +154,7 @@ export class PrecedenceGraph<T> {
     }
   }
 
-  removeEdge(downstream: T, upstream: T): void {
+  removeEdge(upstream: T, downstream: T): void {
     // FIXME: switch order.
     const deps = this.adjacencyMap.get(downstream);
     if (deps?.has(upstream) ?? false) {
@@ -181,8 +181,8 @@ export class PrecedenceGraph<T> {
 
   /**
    * Return a representation that conforms with the syntax of mermaid.js
-   * @param edgesWithIssue Edges in the **dependency** graph that causes issues
-   * to the execution. A set containing arrays with [effect, origin].
+   * @param edgesWithIssue A set containing arrays with [origin, effect].
+   * Denotes edges in the graph that causes issues to the execution, will be visualized as `--x` in mermaid.
    */
   toMermaidString(edgesWithIssue?: Set<[T, T]>): string {
     if (edgesWithIssue == null) edgesWithIssue = new Set();
@@ -201,6 +201,10 @@ export class PrecedenceGraph<T> {
     };
 
     // Build a block here since we only need `counter` temporarily here
+
+    // We use numbers instead of names of reactors directly as node names
+    // in mermaid.js because mermaid has strict restrictions regarding
+    // what could be used as names of the node. 
     {
       let counter = 0;
       for (const v of this.getNodes()) {
@@ -357,7 +361,7 @@ export class SortablePrecedenceGraph<
     const search = (parentNode: T, nodes: Set<R>): void => {
       for (const node of nodes) {
         if (node instanceof type) {
-          collapsed.addEdge(parentNode, node);
+          collapsed.addEdge(node, parentNode);
           if (!visited.has(node)) {
             visited.add(node);
             search(node, apg.getUpstreamNeighbors(node));

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -305,6 +305,7 @@ export class DependencyGraph<T> {
     {
       let counter = 0;
       for (const v of this.getNodes()) {
+        result += `\n\t${counter}["${getNodeString(v, String(counter))}"]`
         nodeToNumber.set(v, counter++);
       }
     }
@@ -312,9 +313,9 @@ export class DependencyGraph<T> {
     for (const s of this.getNodes()) {
       // This is the origin
       for (const t of this.getOriginsOfEffect(s)) {
-        result += `\n\t${nodeToNumber.get(t)}["${getNodeString(t, String(nodeToNumber.get(t)))}"]`;
+        result += `\n\t${nodeToNumber.get(t)}`;
         result += edgesWithIssue.has([s, t]) ? " --x " : " --> ";
-        result += `${nodeToNumber.get(s)}["${getNodeString(s, String(nodeToNumber.get(s)))}"]`;
+        result += `${nodeToNumber.get(s)}`;
       }
     }
     return result;

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -151,7 +151,6 @@ export class DependencyGraph<T> {
   }
 
   getOriginsOfEffect(node: T): Set<T> {
-    // FIXME: use different terminology: origins/effects
     const nodes = this.adjacencyMap.get(node);
     if (nodes !== undefined) {
       return nodes;
@@ -260,30 +259,6 @@ export class DependencyGraph<T> {
     // nodes in the graph.
     if (!this.adjacencyMap.has(origin)) {
       this.adjacencyMap.set(origin, new Set());
-    }
-  }
-
-  addBackEdges(node: T, dependentNodes: Set<T>): void {
-    for (const a of dependentNodes) {
-      this.addEdge(a, node);
-    }
-  }
-
-  addEdges(node: T, dependsOn: Set<T>): void {
-    const deps = this.adjacencyMap.get(node);
-    if (deps == null) {
-      this.adjacencyMap.set(node, new Set(dependsOn));
-      this.numberOfEdges += dependsOn.size;
-    } else {
-      for (const dependency of dependsOn) {
-        if (!deps.has(dependency)) {
-          deps.add(dependency);
-          this.numberOfEdges++;
-        }
-        if (!this.adjacencyMap.has(dependency)) {
-          this.adjacencyMap.set(dependency, new Set());
-        }
-      }
     }
   }
 

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -185,11 +185,11 @@ export class PrecedenceGraph<T> {
 
   /**
    * Return a representation that conforms with the syntax of mermaid.js
-   * @param edgesWithIssue A set containing arrays with [origin, effect].
+   * @param edgesWithIssue An array containing arrays with [origin, effect].
    * Denotes edges in the graph that causes issues to the execution, will be visualized as `--x` in mermaid.
    */
-  toMermaidString(edgesWithIssue?: Set<[T, T]>): string {
-    if (edgesWithIssue == null) edgesWithIssue = new Set();
+  toMermaidString(edgesWithIssue?: Array<[T, T]>): string {
+    if (edgesWithIssue == null) edgesWithIssue = [];
     let result = "graph";
     const nodeToNumber = new Map<T, number>();
     const getNodeString = (node: T, def: string): string => {
@@ -221,7 +221,7 @@ export class PrecedenceGraph<T> {
       // This is the origin
       for (const t of this.getUpstreamNeighbors(s)) {
         result += `\n${nodeToNumber.get(t)}`;
-        result += edgesWithIssue.has([s, t]) ? " --x " : " --> ";
+        result += edgesWithIssue.some((v) => v[0] === t && v[1] === s) ? " --x " : " --> ";
         result += `${nodeToNumber.get(s)}`;
       }
     }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -3,6 +3,7 @@
  * @author Marten Lohstroh <marten@berkeley.edu>
  */
 
+import { Reaction } from "./reaction";
 import type {Sortable} from "./types";
 import {Log} from "./util";
 
@@ -450,4 +451,13 @@ export class SortablePrecedenceGraph<
       return true;
     }
   }
+}
+
+/**
+ * A sortable precedence graph for reactions.
+ */
+export class ReactionGraph extends SortablePrecedenceGraph<Reaction<unknown>> {
+    constructor(pg?: PrecedenceGraph<unknown>) {
+        super(Reaction<unknown>, pg)
+    }
 }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -184,7 +184,7 @@ export class DependencyGraph<T> {
       for (const next of this.getOriginsOfEffect(current)) {
         if (!visited.has(next)) search(next);
       }
-    }
+    };
     search(effect);
     reachable.delete(effect);
 
@@ -197,9 +197,9 @@ export class DependencyGraph<T> {
    * Refer to https://stackoverflow.com/a/56317289
    */
   hasCycle(): boolean {
-    const stack = new Array<T>;
-    const visited = new Set<T>;
-    const currentDirectAncestors = new Set<T>;
+    const stack = new Array<T>();
+    const visited = new Set<T>();
+    const currentDirectAncestors = new Set<T>();
 
     for (const v of this.getNodes()) {
       if (visited.has(v)) {
@@ -280,7 +280,7 @@ export class DependencyGraph<T> {
     return this.adjacencyMap.keys();
   }
 
-  toString : (() => string) = (() => this.toMermaidRepresentation());
+  toString: () => string = () => this.toMermaidRepresentation();
 
   /**
    * Return a representation that conforms with the syntax of mermaid.js
@@ -294,7 +294,9 @@ export class DependencyGraph<T> {
     const getNodeString = (node: T, def: string): string => {
       if (node == null || node?.toString === Object.prototype.toString) {
         console.error(
-          `Encountered node with no toString() implementation: ${String(node?.constructor)}`
+          `Encountered node with no toString() implementation: ${String(
+            node?.constructor
+          )}`
         );
         return def;
       }
@@ -305,7 +307,7 @@ export class DependencyGraph<T> {
     {
       let counter = 0;
       for (const v of this.getNodes()) {
-        result += `\n${counter}["${getNodeString(v, String(counter))}"]`
+        result += `\n${counter}["${getNodeString(v, String(counter))}"]`;
         nodeToNumber.set(v, counter++);
       }
     }
@@ -446,12 +448,13 @@ export class SortableDependencyGraph<
   T extends Sortable<number>
 > extends DependencyGraph<T> {
   static fromDependencyGraph<R, T extends Sortable<number>>(
-      apg: DependencyGraph<R>, 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      type: new (...args: any[]) => T): SortableDependencyGraph<T> {
+    apg: DependencyGraph<R>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type: new (...args: any[]) => T
+  ): SortableDependencyGraph<T> {
     const collapsed = new SortableDependencyGraph<T>();
 
-    // Originally from reactor.ts. 
+    // Originally from reactor.ts.
     // This removes all nodes that are not of type `T`,
     // and reassign node relationship in a way that preserves original lineage.
     const visited = new Set();
@@ -467,7 +470,7 @@ export class SortableDependencyGraph<
           search(parentNode, apg.getOriginsOfEffect(node));
         }
       }
-    }
+    };
     const leafs = apg.pureEffectNodes();
     for (const leaf of leafs) {
       if (leaf instanceof type) {

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -221,7 +221,9 @@ export class PrecedenceGraph<T> {
       // This is the origin
       for (const t of this.getUpstreamNeighbors(s)) {
         result += `\n${nodeToNumber.get(t)}`;
-        result += edgesWithIssue.some((v) => v[0] === t && v[1] === s) ? " --x " : " --> ";
+        result += edgesWithIssue.some((v) => v[0] === t && v[1] === s)
+          ? " --x "
+          : " --> ";
         result += `${nodeToNumber.get(s)}`;
       }
     }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -451,19 +451,20 @@ export class SortableDependencyGraph<
       type: new (...args: any[]) => T): SortableDependencyGraph<T> {
     const collapsed = new SortableDependencyGraph<T>();
 
-    // Originally from reactor.ts. This removes all nodes that are not of type `Sortable<number>`,
-    // And reassign node relationship, preserving original lineage.
+    // Originally from reactor.ts. 
+    // This removes all nodes that are not of type `T`,
+    // and reassign node relationship in a way that preserves original lineage.
     const visited = new Set();
-    const search = (reaction: T, nodes: Set<R>): void => {
+    const search = (parentNode: T, nodes: Set<R>): void => {
       for (const node of nodes) {
         if (node instanceof type) {
-          collapsed.addEdge(reaction, node);
+          collapsed.addEdge(parentNode, node);
           if (!visited.has(node)) {
             visited.add(node);
             search(node, apg.getOriginsOfEffect(node));
           }
         } else {
-          search(reaction, apg.getOriginsOfEffect(node));
+          search(parentNode, apg.getOriginsOfEffect(node));
         }
       }
     }
@@ -479,6 +480,7 @@ export class SortableDependencyGraph<
     return collapsed;
   }
 
+  // This implements Kahn's algorithm
   updatePriorities(destructive: boolean, spacing = 100): boolean {
     const start = new Array<T>();
     let graph: Map<T, Set<T>>;

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -1,9 +1,9 @@
 /**
- * @file A collection of classes for dealing with graphs.
+ * @file A collection of classes for handling graphs.
  * @author Marten Lohstroh <marten@berkeley.edu>
  */
 
-import { Reaction } from "./reaction";
+import {Reaction} from "./reaction";
 import type {Sortable} from "./types";
 import {Log} from "./util";
 
@@ -457,7 +457,7 @@ export class SortablePrecedenceGraph<
  * A sortable precedence graph for reactions.
  */
 export class ReactionGraph extends SortablePrecedenceGraph<Reaction<unknown>> {
-    constructor(pg?: PrecedenceGraph<unknown>) {
-        super(Reaction<unknown>, pg)
-    }
+  constructor(pg?: PrecedenceGraph<unknown>) {
+    super(Reaction<unknown>, pg);
+  }
 }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -305,7 +305,7 @@ export class DependencyGraph<T> {
     {
       let counter = 0;
       for (const v of this.getNodes()) {
-        result += `\n\t${counter}["${getNodeString(v, String(counter))}"]`
+        result += `\n${counter}["${getNodeString(v, String(counter))}"]`
         nodeToNumber.set(v, counter++);
       }
     }
@@ -313,7 +313,7 @@ export class DependencyGraph<T> {
     for (const s of this.getNodes()) {
       // This is the origin
       for (const t of this.getOriginsOfEffect(s)) {
-        result += `\n\t${nodeToNumber.get(t)}`;
+        result += `\n${nodeToNumber.get(t)}`;
         result += edgesWithIssue.has([s, t]) ? " --x " : " --> ";
         result += `${nodeToNumber.get(s)}`;
       }

--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -131,11 +131,11 @@ export class PrecedenceGraph<T> {
   }
 
   /**
-   * Add an edge that denotes origin effect relationship,
-   * which, in the underlying dependency graph, has direction effect->origin.
+   * Add an edge from an upstream node to a downstream one.
+   * @param upstream The node at which the directed edge starts.
+   * @param downstream The node at which the directed edge ends.
    */
   addEdge(upstream: T, downstream: T): void {
-    // FIXME: switch order.
     const deps = this.adjacencyMap.get(downstream);
     if (deps == null) {
       this.adjacencyMap.set(downstream, new Set([upstream]));
@@ -154,8 +154,12 @@ export class PrecedenceGraph<T> {
     }
   }
 
+  /**
+   * Remove a directed edge from an upstream node to a downstream one.
+   * @param upstream The node at which the directed edge starts.
+   * @param downstream The node at which the directed edge ends.
+   */
   removeEdge(upstream: T, downstream: T): void {
-    // FIXME: switch order.
     const deps = this.adjacencyMap.get(downstream);
     if (deps?.has(upstream) ?? false) {
       deps?.delete(upstream);
@@ -204,7 +208,7 @@ export class PrecedenceGraph<T> {
 
     // We use numbers instead of names of reactors directly as node names
     // in mermaid.js because mermaid has strict restrictions regarding
-    // what could be used as names of the node. 
+    // what could be used as names of the node.
     {
       let counter = 0;
       for (const v of this.getNodes()) {

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -2,6 +2,7 @@ export * from "./types";
 export * from "./strings";
 export * from "./time";
 export * from "./util";
+export * from "./queue";
 export * from "./graph";
 export * from "./reaction";
 export * from "./component";

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -45,10 +45,7 @@ export abstract class Port<T extends Present> extends Trigger {
     Log.debug(this, () => "In isPresent()...");
     Log.debug(this, () => `value: ${this.value?.toString()}`);
     Log.debug(this, () => `tag: ${this.tag}`);
-    Log.debug(
-      this,
-      () => `time: ${this.runtime.util.getCurrentLogicalTime()}`
-    );
+    Log.debug(this, () => `time: ${this.runtime.util.getCurrentLogicalTime()}`);
 
     if (
       this.value !== undefined &&

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -1,0 +1,105 @@
+export interface PrioritySetElement<P> {
+  /**
+   * Pointer to the next node in the priority set.
+   */
+  next: PrioritySetElement<P> | undefined;
+
+  /**
+   * Return the priority of this node.
+   */
+  getPriority: () => P;
+
+  /**
+   * Determine whether this node has priority over the given node or not.
+   * @param node A node to compare the priority of this node to.
+   */
+  hasPriorityOver: (node: PrioritySetElement<P>) => boolean;
+
+  /**
+   * If the given node is considered a duplicate of this node, then
+   * update this node if needed, and return true. Return false otherwise.
+   * @param node A node that may or may not be a duplicate of this node.
+   */
+  updateIfDuplicateOf: (node: PrioritySetElement<P> | undefined) => boolean;
+}
+
+/**
+ * A priority queue that overwrites duplicate entries.
+ */
+export class PrioritySet<P> {
+  private head: PrioritySetElement<P> | undefined;
+
+  private count = 0;
+
+  push(element: PrioritySetElement<P>): void {
+    // update linked list
+    if (this.head === undefined) {
+      // create head
+      element.next = undefined;
+      this.head = element;
+      this.count++;
+    } else if (element.updateIfDuplicateOf(this.head)) {
+      // updateIfDuplicateOf returned true, i.e.,
+      // it has updated the value of this.head to
+      // equal that of element.
+    } else {
+      // prepend
+      if (element.hasPriorityOver(this.head)) {
+        element.next = this.head;
+        this.head = element;
+        this.count++;
+        return;
+      }
+      // seek
+      let curr: PrioritySetElement<P> | undefined = this.head;
+      while (curr != null) {
+        const next: PrioritySetElement<P> | undefined = curr.next;
+        if (next != null) {
+          if (element.updateIfDuplicateOf(next)) {
+            // updateIfDuplicateOf returned true, i.e.,
+            // it has updated the value of this.head to
+            // equal that of element.
+            return;
+          } else if (element.hasPriorityOver(next)) {
+            break;
+          } else {
+            curr = next;
+          }
+        } else {
+          break;
+        }
+      }
+      if (curr != null) {
+        // insert
+        element.next = curr.next; // undefined if last
+        curr.next = element;
+        this.count++;
+      }
+    }
+  }
+
+  pop(): PrioritySetElement<P> | undefined {
+    if (this.head != null) {
+      const node = this.head;
+      this.head = this.head.next;
+      node.next = undefined; // unhook from linked list
+      this.count--;
+      return node;
+    }
+  }
+
+  peek(): PrioritySetElement<P> | undefined {
+    if (this.head != null) {
+      return this.head;
+    }
+  }
+
+  size(): number {
+    return this.count;
+  }
+
+  empty(): void {
+    this.head = undefined;
+    this.count = 0;
+  }
+}

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -1,3 +1,11 @@
+/**
+ * @file A collection of classes for handling queues.
+ * @author Marten Lohstroh <marten@berkeley.edu>
+ */
+
+/**
+ * Interface for prioritized elements than be hooked into a linked list.
+ */
 export interface PrioritySetElement<P> {
   /**
    * Pointer to the next node in the priority set.
@@ -10,7 +18,7 @@ export interface PrioritySetElement<P> {
   getPriority: () => P;
 
   /**
-   * Determine whether this node has priority over the given node or not.
+   * Return true if this node has priority over the given node, false otherwise.
    * @param node A node to compare the priority of this node to.
    */
   hasPriorityOver: (node: PrioritySetElement<P>) => boolean;
@@ -24,13 +32,55 @@ export interface PrioritySetElement<P> {
 }
 
 /**
- * A priority queue that overwrites duplicate entries.
+ * A deduplicating priority queue that overwrites duplicate entries,
+ * based on a singly-linked list.
  */
 export class PrioritySet<P> {
-  private head: PrioritySetElement<P> | undefined;
-
+  /**
+   * The number of elements in the queue.
+   */
   private count = 0;
 
+  /**
+   * The first-in-line element in the queue.
+   */
+  private head: PrioritySetElement<P> | undefined;
+
+  /**
+   * Empty the queue.
+   */
+  empty(): void {
+    this.head = undefined;
+    this.count = 0;
+  }
+
+  /**
+   * Return the first-in-line element of the queue, but do not remove it.
+   */
+  peek(): PrioritySetElement<P> | undefined {
+    if (this.head != null) {
+      return this.head;
+    }
+  }
+
+  /**
+   * Return the first-in-line element of the queue and remove it.
+   */
+  pop(): PrioritySetElement<P> | undefined {
+    if (this.head != null) {
+      const node = this.head;
+      this.head = this.head.next;
+      node.next = undefined; // unhook from linked list
+      this.count--;
+      return node;
+    }
+  }
+
+  /**
+   * Insert a new element into the queue based on its priority.
+   * If a duplicate entry already exists, abort the insertion.
+   * @param element The element to push onto the queue.
+   */
   push(element: PrioritySetElement<P>): void {
     // update linked list
     if (this.head === undefined) {
@@ -78,28 +128,10 @@ export class PrioritySet<P> {
     }
   }
 
-  pop(): PrioritySetElement<P> | undefined {
-    if (this.head != null) {
-      const node = this.head;
-      this.head = this.head.next;
-      node.next = undefined; // unhook from linked list
-      this.count--;
-      return node;
-    }
-  }
-
-  peek(): PrioritySetElement<P> | undefined {
-    if (this.head != null) {
-      return this.head;
-    }
-  }
-
+  /**
+   * Return the number of elements in the queue.
+   */
   size(): number {
     return this.count;
-  }
-
-  empty(): void {
-    this.head = undefined;
-    this.count = 0;
   }
 }

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -105,7 +105,7 @@ export class Reaction<T>
    * @param another Reaction to compare this reaction's priority against.
    */
   hasPriorityOver(another: PrioritySetElement<Priority> | undefined): boolean {
-    if (another !== undefined && this.getPriority() < another.getPriority()) {
+    if (another != null && this.getPriority() < another.getPriority()) {
       return true;
     } else {
       return false;

--- a/src/core/reaction.ts
+++ b/src/core/reaction.ts
@@ -105,7 +105,7 @@ export class Reaction<T>
    * @param another Reaction to compare this reaction's priority against.
    */
   hasPriorityOver(another: PrioritySetElement<Priority> | undefined): boolean {
-    if (another != null && this.getPriority() < another.getPriority()) {
+    if (another !== undefined && this.getPriority() < another.getPriority()) {
       return true;
     } else {
       return false;

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -6,7 +6,7 @@
  * @author Hokeun Kim (hokeunkim@berkeley.edu)
  */
 
-import type {
+import {
   Priority,
   Absent,
   ArgList,
@@ -15,7 +15,8 @@ import type {
   Sched,
   Variable,
   Write,
-  TriggerManager
+  TriggerManager,
+  ReactionGraph
 } from "./internal";
 import {
   TimeValue,
@@ -24,7 +25,6 @@ import {
   getCurrentPhysicalTime,
   Alarm,
   PrioritySet,
-  SortablePrecedenceGraph,
   Log,
   PrecedenceGraph,
   Reaction,
@@ -2583,7 +2583,7 @@ export class App extends Reactor {
     Log.debug(this, () => "Before collapse: " + apg.toString());
 
     // 1. Collapse dependencies and weed out the ports.
-    const collapsed = new SortablePrecedenceGraph(Reaction<unknown>, apg);
+    const collapsed = new ReactionGraph(apg);
 
     // 2. Update priorities.
     Log.debug(this, () => "After collapse: " + collapsed.toString());

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2583,10 +2583,7 @@ export class App extends Reactor {
     Log.debug(this, () => "Before collapse: " + apg.toString());
 
     // 1. Collapse dependencies and weed out the ports.
-    const collapsed = SortablePrecedenceGraph.fromPrecedenceGraph(
-        apg,
-        Reaction<unknown>
-      );
+    const collapsed = new SortablePrecedenceGraph(Reaction<unknown>, apg);
 
     // 2. Update priorities.
     Log.debug(this, () => "After collapse: " + collapsed.toString());

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -864,7 +864,7 @@ export abstract class Reactor extends Component {
       const procedure = p.getManager(this._getKey(p)).getProcedure();
       const lastCaller = p.getManager(this._getKey(p)).getLastCaller();
       if (procedure != null && lastCaller != null) {
-        const effects = this._dependencyGraph.getEffectsOfOrigin(procedure);
+        const effects = this._dependencyGraph.getParents(procedure);
         for (const e of effects) {
           if (!(e instanceof CalleePort)) {
             // Also add edge to the local graph.
@@ -1080,7 +1080,7 @@ export abstract class Reactor extends Component {
     // Check the race condition
     //   - between reactors and reactions (NOTE: check also needs to happen
     //     in addReaction)
-    const deps = this._dependencyGraph.getOriginsOfEffect(dst); // FIXME this will change with multiplex ports
+    const deps = this._dependencyGraph.getChildren(dst); // FIXME this will change with multiplex ports
     if (deps !== undefined && deps.size > 0) {
       throw Error("Destination port is already occupied.");
     }
@@ -1093,7 +1093,7 @@ export abstract class Reactor extends Component {
       // console.log("IOPort")
       // Rule out write conflicts.
       //   - (between reactors)
-      if (this._dependencyGraph.getEffectsOfOrigin(dst).size > 0) {
+      if (this._dependencyGraph.getParents(dst).size > 0) {
         return false;
       }
 
@@ -1321,7 +1321,7 @@ export abstract class Reactor extends Component {
       const callerManager = src.getManager(this._getKey(src));
       const container = callerManager.getContainer();
       const callers = new Set<Reaction<any>>();
-      container._dependencyGraph.getEffectsOfOrigin(src).forEach((dep) => {
+      container._dependencyGraph.getParents(src).forEach((dep) => {
         if (dep instanceof Reaction) {
           callers.add(dep);
         }
@@ -1369,7 +1369,7 @@ export abstract class Reactor extends Component {
           if (node instanceof InPort && inputs.has(node as InPort<Present>)) {
             ifGraph.addEdge(output, node);
           } else {
-            search(output, this._dependencyGraph.getOriginsOfEffect(output));
+            search(output, this._dependencyGraph.getChildren(output));
           }
         }
       }
@@ -1378,7 +1378,7 @@ export abstract class Reactor extends Component {
     // For each output, walk the graph and add dependencies to
     // the inputs that are reachable.
     for (const output of outputs) {
-      search(output, this._dependencyGraph.getOriginsOfEffect(output));
+      search(output, this._dependencyGraph.getChildren(output));
       visited.clear();
     }
 
@@ -1465,7 +1465,7 @@ export abstract class Reactor extends Component {
       src.getManager(this._getKey(src)).delReceiver(writer as WritablePort<S>);
       this._dependencyGraph.removeEdge(dst, src);
     } else {
-      const nodes = this._dependencyGraph.getEffectsOfOrigin(src);
+      const nodes = this._dependencyGraph.getParents(src);
       for (const node of nodes) {
         if (node instanceof IOPort) {
           const writer = node.asWritable(this._getKey(node));

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -864,7 +864,7 @@ export abstract class Reactor extends Component {
       const procedure = p.getManager(this._getKey(p)).getProcedure();
       const lastCaller = p.getManager(this._getKey(p)).getLastCaller();
       if (procedure != null && lastCaller != null) {
-        const effects = this._dependencyGraph.getDownstreamNodes(procedure);
+        const effects = this._dependencyGraph.getDownstream(procedure);
         for (const e of effects) {
           if (!(e instanceof CalleePort)) {
             // Also add edge to the local graph.
@@ -1080,7 +1080,7 @@ export abstract class Reactor extends Component {
     // Check the race condition
     //   - between reactors and reactions (NOTE: check also needs to happen
     //     in addReaction)
-    const deps = this._dependencyGraph.getUpstreamNodes(dst); // FIXME this will change with multiplex ports
+    const deps = this._dependencyGraph.getUpstream(dst); // FIXME this will change with multiplex ports
     if (deps !== undefined && deps.size > 0) {
       throw Error("Destination port is already occupied.");
     }
@@ -1093,7 +1093,7 @@ export abstract class Reactor extends Component {
       // console.log("IOPort")
       // Rule out write conflicts.
       //   - (between reactors)
-      if (this._dependencyGraph.getDownstreamNodes(dst).size > 0) {
+      if (this._dependencyGraph.getDownstream(dst).size > 0) {
         return false;
       }
 
@@ -1321,7 +1321,7 @@ export abstract class Reactor extends Component {
       const callerManager = src.getManager(this._getKey(src));
       const container = callerManager.getContainer();
       const callers = new Set<Reaction<any>>();
-      container._dependencyGraph.getDownstreamNodes(src).forEach((dep) => {
+      container._dependencyGraph.getDownstream(src).forEach((dep) => {
         if (dep instanceof Reaction) {
           callers.add(dep);
         }
@@ -1369,7 +1369,7 @@ export abstract class Reactor extends Component {
           if (node instanceof InPort && inputs.has(node as InPort<Present>)) {
             ifGraph.addEdge(output, node);
           } else {
-            search(output, this._dependencyGraph.getUpstreamNodes(output));
+            search(output, this._dependencyGraph.getUpstream(output));
           }
         }
       }
@@ -1378,7 +1378,7 @@ export abstract class Reactor extends Component {
     // For each output, walk the graph and add dependencies to
     // the inputs that are reachable.
     for (const output of outputs) {
-      search(output, this._dependencyGraph.getUpstreamNodes(output));
+      search(output, this._dependencyGraph.getUpstream(output));
       visited.clear();
     }
 
@@ -1465,7 +1465,7 @@ export abstract class Reactor extends Component {
       src.getManager(this._getKey(src)).delReceiver(writer as WritablePort<S>);
       this._dependencyGraph.removeEdge(dst, src);
     } else {
-      const nodes = this._dependencyGraph.getDownstreamNodes(src);
+      const nodes = this._dependencyGraph.getDownstream(src);
       for (const node of nodes) {
         if (node instanceof IOPort) {
           const writer = node.asWritable(this._getKey(node));

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -677,7 +677,10 @@ export abstract class Reactor extends Component {
     // Make effects dependent on sources.
     for (const effect of effects) {
       for (const source of sources) {
-        this._causalityGraph.addEdge(effect as Port<Present>, source as Port<Present>);
+        this._causalityGraph.addEdge(
+          effect as Port<Present>,
+          source as Port<Present>
+        );
       }
     }
   }
@@ -775,9 +778,7 @@ export abstract class Reactor extends Component {
       );
       if (trigs.list.length > 1) {
         // A procedure can only have a single trigger.
-        throw new Error(
-          `Procedure "${procedure}" has multiple triggers.`
-        );
+        throw new Error(`Procedure "${procedure}" has multiple triggers.`);
       }
       procedure.active = true;
       this._recordDeps(procedure);
@@ -1372,7 +1373,7 @@ export abstract class Reactor extends Component {
           }
         }
       }
-    }
+    };
 
     // For each output, walk the graph and add dependencies to
     // the inputs that are reachable.
@@ -2267,10 +2268,7 @@ export class App extends Reactor {
         r = this._reactionQ.pop();
         r.doReact();
       } catch (e) {
-        Log.error(
-          this,
-          () => `Exception occurred in reaction: ${r}: ${e}`
-        );
+        Log.error(this, () => `Exception occurred in reaction: ${r}: ${e}`);
         // Allow errors in reactions to kill execution.
         throw e;
       }
@@ -2337,10 +2335,7 @@ export class App extends Reactor {
         while (nextEvent?.tag.isSimultaneousWith(this._currentTag) ?? false) {
           const trigger = nextEvent?.trigger;
           this._eventQ.pop();
-          Log.debug(
-            this,
-            () => `Popped off the event queue: ${trigger}`
-          );
+          Log.debug(this, () => `Popped off the event queue: ${trigger}`);
           // Handle timers.
           if (trigger instanceof Timer) {
             if (!trigger.period.isZero()) {
@@ -2586,9 +2581,12 @@ export class App extends Reactor {
     console.log(apg.toString());
 
     Log.debug(this, () => "Before collapse: " + apg.toString());
-    
+
     // 1. Collapse dependencies and weed out the ports.
-    const collapsed = SortableDependencyGraph.fromDependencyGraph(apg, Reaction<unknown>);
+    const collapsed = SortableDependencyGraph.fromDependencyGraph(
+      apg,
+      Reaction<unknown>
+    );
 
     // 2. Update priorities.
     Log.debug(this, () => "After collapse: " + collapsed.toString());
@@ -2636,10 +2634,7 @@ export class App extends Reactor {
         this._startOfExecution.add(this._executionTimeout),
         0
       );
-      Log.debug(
-        this,
-        () => `Execution timeout: ${this._executionTimeout}`
-      );
+      Log.debug(this, () => `Execution timeout: ${this._executionTimeout}`);
 
       // If there is a known end of execution, schedule a shutdown reaction to that effect.
       this.__runtime.schedule(

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2586,7 +2586,7 @@ export class App extends Reactor {
     console.log(apg.toString());
 
     Log.debug(this, () => "Before collapse: " + apg.toString());
-/*     const collapsed = new SortableDependencyGraph();
+    const collapsed = new SortableDependencyGraph();
 
     // 1. Collapse dependencies and weed out the ports.
     const leafs = apg.pureEffectNodes();
@@ -2618,9 +2618,9 @@ export class App extends Reactor {
     }
 
     // 2. Update priorities.
-    Log.debug(this, () => "After collapse: " + collapsed.toString()); */
+    Log.debug(this, () => "After collapse: " + collapsed.toString());
 
-    if (!apg.hasCycle()) {
+    if (collapsed.updatePriorities(true)) {
       Log.global.debug("No cycles.");
     } else {
       throw new Error("Cycle in reaction graph.");

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2586,36 +2586,9 @@ export class App extends Reactor {
     console.log(apg.toString());
 
     Log.debug(this, () => "Before collapse: " + apg.toString());
-    const collapsed = new SortableDependencyGraph();
-
+    
     // 1. Collapse dependencies and weed out the ports.
-    const leafs = apg.pureEffectNodes();
-    const visited = new Set();
-
-    function search(
-      reaction: Reaction<unknown>,
-      nodes: Set<Port<Present> | Reaction<unknown>>
-    ): void {
-      for (const node of nodes) {
-        if (node instanceof Reaction) {
-          collapsed.addEdge(reaction, node);
-          if (!visited.has(node)) {
-            visited.add(node);
-            search(node, apg.getOriginsOfEffect(node));
-          }
-        } else {
-          search(reaction, apg.getOriginsOfEffect(node));
-        }
-      }
-    }
-
-    for (const leaf of leafs) {
-      if (leaf instanceof Reaction) {
-        collapsed.addNode(leaf);
-        search(leaf, apg.getOriginsOfEffect(leaf));
-        visited.clear();
-      }
-    }
+    const collapsed = SortableDependencyGraph.fromDependencyGraph(apg, Reaction<unknown>);
 
     // 2. Update priorities.
     Log.debug(this, () => "After collapse: " + collapsed.toString());

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -676,10 +676,9 @@ export abstract class Reactor extends Component {
     }
     // Make effects dependent on sources.
     for (const effect of effects) {
-      this._causalityGraph.addEdges(
-        effect as Port<Present>,
-        sources as Set<Port<Present>>
-      );
+      for (const source of sources) {
+        this._causalityGraph.addEdge(effect as Port<Present>, source as Port<Present>);
+      }
     }
   }
 

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2586,7 +2586,7 @@ export class App extends Reactor {
     console.log(apg.toString());
 
     Log.debug(this, () => "Before collapse: " + apg.toString());
-    const collapsed = new SortableDependencyGraph();
+/*     const collapsed = new SortableDependencyGraph();
 
     // 1. Collapse dependencies and weed out the ports.
     const leafs = apg.pureEffectNodes();
@@ -2618,9 +2618,9 @@ export class App extends Reactor {
     }
 
     // 2. Update priorities.
-    Log.debug(this, () => "After collapse: " + collapsed.toString());
+    Log.debug(this, () => "After collapse: " + collapsed.toString()); */
 
-    if (collapsed.updatePriorities(true)) {
+    if (!apg.hasCycle()) {
       Log.global.debug("No cycles.");
     } else {
       throw new Error("Cycle in reaction graph.");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -110,6 +110,13 @@ export class Triggers {
   }
 }
 
+export interface Sortable<P> {
+    setPriority: (priority: P) => void;
+  
+    // getSTPUntil(): TimeInstant
+    // setSTPUntil(): TimeInstant
+  }  
+
 /**
  * Interface for schedulable actions.
  */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -111,11 +111,11 @@ export class Triggers {
 }
 
 export interface Sortable<P> {
-    setPriority: (priority: P) => void;
-  
-    // getSTPUntil(): TimeInstant
-    // setSTPUntil(): TimeInstant
-  }  
+  setPriority: (priority: P) => void;
+
+  // getSTPUntil(): TimeInstant
+  // setSTPUntil(): TimeInstant
+}
 
 /**
  * Interface for schedulable actions.


### PR DESCRIPTION
This PR fixes #166. 
- [x] Rename APIs so they less confusing
- [x] Remove unused or redundant APIs (removed `addBackEdges`/`addEdges`)
- [x] Move `toString` to use `mermaid.js` representation
- [x] Rewrite search functions to use iteration, and use more efficient algorithm (rewrote `hasCycle`; the one in `fromDependencyGraph` will incur some overhead so omitted)
- [x] Refactor improper use of graph APIs in `Reactor`
