### PR TITLE
More `eslint` issues addressed

### DIFF
--- a/__tests__/Adder.test.ts
+++ b/__tests__/Adder.test.ts
@@ -29,7 +29,7 @@ class MyAdder extends Adder {
     }
   }
 
-  public getProxy(port: IOPort<unknown>) {
+  public getProxy<T>(port: IOPort<T>) {
     return this.writable(port);
   }
 }

--- a/__tests__/HierarchicalSingleEvent.test.ts
+++ b/__tests__/HierarchicalSingleEvent.test.ts
@@ -12,7 +12,7 @@ import {Logger} from "../src/share/Logger";
 
 class SEContainer extends Reactor {
   // Made these public to accommodate the test below.
-  public o: OutPort<any> = new OutPort<any>(this);
+  public o: OutPort<unknown> = new OutPort(this);
 
   public child = new SingleEvent<string>(this, new Parameter("Foo"));
 
@@ -24,7 +24,7 @@ class SEContainer extends Reactor {
 
 class LogContainer extends Reactor {
   // Made these public to accommodate the test below.
-  public i: InPort<any> = new InPort<any>(this);
+  public i: InPort<unknown> = new InPort(this);
 
   public child: Logger = new Logger(this, "Foo");
 

--- a/__tests__/HierarchicalSingleEvent.test.ts
+++ b/__tests__/HierarchicalSingleEvent.test.ts
@@ -12,7 +12,7 @@ import {Logger} from "../src/share/Logger";
 
 class SEContainer extends Reactor {
   // Made these public to accommodate the test below.
-  public o: OutPort<unknown> = new OutPort(this);
+  public o: OutPort<string> = new OutPort(this);
 
   public child = new SingleEvent<string>(this, new Parameter("Foo"));
 
@@ -24,7 +24,7 @@ class SEContainer extends Reactor {
 
 class LogContainer extends Reactor {
   // Made these public to accommodate the test below.
-  public i: InPort<unknown> = new InPort(this);
+  public i: InPort<string> = new InPort(this);
 
   public child: Logger = new Logger(this, "Foo");
 

--- a/__tests__/SingleEvent.test.ts
+++ b/__tests__/SingleEvent.test.ts
@@ -3,7 +3,7 @@ import {SingleEvent} from "../src/share/SingleEvent";
 import {Logger} from "../src/share/Logger";
 
 class SETest extends App {
-  singleEvent: SingleEvent<unknown>;
+  singleEvent: SingleEvent<string>;
 
   logger: Logger;
 

--- a/__tests__/SingleEvent.test.ts
+++ b/__tests__/SingleEvent.test.ts
@@ -3,7 +3,7 @@ import {SingleEvent} from "../src/share/SingleEvent";
 import {Logger} from "../src/share/Logger";
 
 class SETest extends App {
-  singleEvent: SingleEvent<any>;
+  singleEvent: SingleEvent<unknown>;
 
   logger: Logger;
 

--- a/__tests__/bank.ts
+++ b/__tests__/bank.ts
@@ -7,9 +7,7 @@ import {
   InPort,
   TimeValue,
   OutMultiPort,
-  Port,
-  MultiPort,
-  IOPort
+  Port
 } from "../src/core/internal";
 
 class Periodic extends Reactor {
@@ -64,8 +62,8 @@ describe("Check bank index", () => {
         );
       });
 
-      const allWriter = this.d.allWritable(this.d.port((member) => member.o as MultiPort<unknown>));
-      const writer = this.b.writable(this.b.port((member) => member.o as IOPort<unknown>));
+      const allWriter = this.d.allWritable(this.d.port((member) => member.o));
+      const writer = this.b.writable(this.b.port((member) => member.o));
       test("check multiport width", () => {
         expect(allWriter[0].width()).toBe(2);
       });
@@ -86,7 +84,7 @@ describe("Check bank index", () => {
       it("generic bank", () => {
         this.c.all().forEach((r) => expect(typeof r.input == "number"));
       });
-      var foo = this.b.port((member) => member.o as Port<unknown>);
+      var foo = this.b.port((member) => member.o);
       var bar = [this.b.get(0).o, this.b.get(1).o, this.b.get(2).o];
       it("select port", () => {
         for (let i = 0; i < foo.length; i++) {

--- a/__tests__/bank.ts
+++ b/__tests__/bank.ts
@@ -7,7 +7,9 @@ import {
   InPort,
   TimeValue,
   OutMultiPort,
-  Port
+  Port,
+  MultiPort,
+  IOPort
 } from "../src/core/internal";
 
 class Periodic extends Reactor {
@@ -62,8 +64,8 @@ describe("Check bank index", () => {
         );
       });
 
-      const allWriter = this.d.allWritable(this.d.port((member) => member.o));
-      const writer = this.b.writable(this.b.port((member) => member.o));
+      const allWriter = this.d.allWritable(this.d.port((member) => member.o as MultiPort<unknown>));
+      const writer = this.b.writable(this.b.port((member) => member.o as IOPort<unknown>));
       test("check multiport width", () => {
         expect(allWriter[0].width()).toBe(2);
       });
@@ -84,7 +86,7 @@ describe("Check bank index", () => {
       it("generic bank", () => {
         this.c.all().forEach((r) => expect(typeof r.input == "number"));
       });
-      var foo = this.b.port((member) => member.o);
+      var foo = this.b.port((member) => member.o as Port<unknown>);
       var bar = [this.b.get(0).o, this.b.get(1).o, this.b.get(2).o];
       it("select port", () => {
         for (let i = 0; i < foo.length; i++) {

--- a/__tests__/dependencies.ts
+++ b/__tests__/dependencies.ts
@@ -1,4 +1,4 @@
-import {Priority, Sortable, ReactionGraph} from "../src/core/internal";
+import {Priority, Sortable, ReactionGraph, dontIndent} from "../src/core/internal";
 import {
   Reactor,
   App,
@@ -6,7 +6,6 @@ import {
   SortablePrecedenceGraph,
   PrioritySet,
   Log,
-  StringUtil
 } from "../src/core/internal";
 
 // Log.setGlobalLevel(Log.levels.DEBUG);
@@ -94,7 +93,7 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(7); // E
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`graph
+      dontIndent`graph
         0["app.R[R3]"]
         1["app.R[R5]"]
         2["app.R[R4]"]
@@ -126,7 +125,7 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[0]).toEqual(6); // V
     expect(graph.size()[1]).toEqual(6); // E
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`graph
+      dontIndent`graph
       0["app.R[R3]"]
       1["app.R[R5]"]
       2["app.R[R4]"]
@@ -148,7 +147,7 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[1]).toEqual(3); // E
     Log.global.debug(graph.toString());
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`graph
+      dontIndent`graph
         0["app.R[R3]"]
         1["app.R[R5]"]
         2["app.R[R4]"]
@@ -168,7 +167,7 @@ describe("Manually constructed precedence graphs", () => {
     expect(graph.size()[1]).toEqual(4); // E
     Log.global.debug(graph.toString());
     expect(graph.toString()).toBe(
-      StringUtil.dontIndent`graph
+      dontIndent`graph
         0["app.R[R3]"]
         1["app.R[R5]"]
         2["app.R[R4]"]

--- a/__tests__/graph.test.ts
+++ b/__tests__/graph.test.ts
@@ -1,7 +1,7 @@
 import {PrioritySet, PrioritySetElement} from "../src/core/queue";
 import type {Sortable} from "../src/core/types";
 import {PrecedenceGraph, SortablePrecedenceGraph} from "../src/core/graph";
-import {StringUtil} from "../src/core/strings";
+
 /**
  * The tests below test the functionality of the hasCycle() utility function on various
  * dependency graphs, in combination with various graph manipulation utilities

--- a/__tests__/simple.ts
+++ b/__tests__/simple.ts
@@ -18,7 +18,7 @@ class MyActor2 extends Reactor {
 
 describe("Test names for contained reactors", () => {
   class myApp extends App {
-    port: InPort<any> = new InPort<any>(this);
+    port: InPort<unknown> = new InPort(this);
 
     x = new MyActor(this);
 

--- a/__tests__/simple.ts
+++ b/__tests__/simple.ts
@@ -1,4 +1,4 @@
-import {Reactor, App, InPort, OutPort, StringUtil} from "../src/core/internal";
+import {Reactor, App, InPort, OutPort, dontIndent} from "../src/core/internal";
 
 class MyActor extends Reactor {
   a = new InPort<{t: number}>(this);
@@ -68,7 +68,7 @@ describe("Test names for contained reactors", () => {
 
       it("graph before connect", () => {
         expect(this._getPrecedenceGraph().toString()).toBe(
-          StringUtil.dontIndent`graph
+          dontIndent`graph
           0["myApp.x[M0]"]
           1["myApp[M0]"]
           2["myApp.y[M0]"]
@@ -91,7 +91,7 @@ describe("Test names for contained reactors", () => {
 
       it("graph after connect and before disconnect", () => {
         expect(this._getPrecedenceGraph().toString()).toBe(
-          StringUtil.dontIndent`graph
+          dontIndent`graph
             0["myApp.x.a"]
             1["myApp.y.b"]
             2["myApp.x[M0]"]
@@ -106,7 +106,7 @@ describe("Test names for contained reactors", () => {
       it("graph after disconnect", () => {
         this._disconnect(this.y.b, this.x.a);
         expect(this._getPrecedenceGraph().toString()).toBe(
-          StringUtil.dontIndent`graph
+          dontIndent`graph
             0["myApp.x.a"]
             1["myApp.y.b"]
             2["myApp.x[M0]"]

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-present-unknown
+master

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-present-unknown
+ts-never

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+present-unknown

--- a/src/core/bank.ts
+++ b/src/core/bank.ts
@@ -1,6 +1,7 @@
 import type {
   IOPort,
   MultiPort,
+  ParmList,
   Port,
   Reactor,
   WritableMultiPort,
@@ -12,14 +13,8 @@ import type {
  * are of type `ReactorArgs`.
  */
 export type ReactorClass<T extends Reactor, S> = new (
-  ...args: ReactorArgs<S>
+  ...parameters: ParmList<S>
 ) => T;
-
-/**
- * Type that describes a tuple of arguments passed into the constructor
- * of a reactor class.
- */
-export type ReactorArgs<T> = T extends any[] ? T : never;
 
 /**
  * A bank of reactor instances.
@@ -40,18 +35,18 @@ export class Bank<T extends Reactor, S> {
    * Construct a new bank of given width on the basis of a given reactor class and a list of arguments.
    * @param width the width of the bank
    * @param cls the class to construct reactor instances of that will populate the bank
-   * @param args the arguments to pass into the constructor of the given reactor class
+   * @param parameters the arguments to pass into the constructor of the given reactor class
    */
   constructor(
     container: Reactor,
     width: number,
     cls: ReactorClass<T, S>,
-    ...args: ReactorArgs<S>
+    ...parameters: ParmList<S>
   ) {
     for (let i = 0; i < width; i++) {
       Bank.initializationMap.set(container, i);
       console.log(`Setting initializing to ${i}`);
-      this.members.push(Reflect.construct(cls, args, cls));
+      this.members.push(Reflect.construct(cls, parameters, cls));
     }
     Bank.initializationMap.delete(container);
   }

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -17,9 +17,7 @@ export abstract class Component {
    * A symbol that identifies this component, and it also used to selectively
    * grant access to its privileged functions.
    */
-  // TODO (axmmisaka): Is instantiating in abstract class a good idea...?
-  // eslint-disable-next-line symbol-description
-  protected _key = Symbol();
+  protected _key = Symbol("Unique component identifier");
 
   /**
    * The container of this component. Each component is contained by a

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -309,10 +309,8 @@ class RTIClient extends EventEmitter {
    * meaning that the type checker cannot check whether uses of the action are type safe.
    * In an alternative design, type information might be preserved. TODO(marten): Look into this.
    */
-  private readonly federatePortActionByID: Map<number, Action<any>> = new Map<
-    number,
-    Action<any>
-  >();
+  private readonly federatePortActionByID: Map<number, Action<unknown>> =
+    new Map<number, Action<unknown>>();
 
   /**
    * Establish the mapping between a federate port's action and its ID.
@@ -323,7 +321,10 @@ class RTIClient extends EventEmitter {
     federatePortID: number,
     federatePortAction: Action<T>
   ): void {
-    this.federatePortActionByID.set(federatePortID, federatePortAction);
+    this.federatePortActionByID.set(
+      federatePortID,
+      federatePortAction as Action<unknown>
+    );
   }
 
   /**

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1124,7 +1124,7 @@ export class FederatedApp extends App {
    */
   private stopRequestInfo: StopRequestInfo = new StopRequestInfo(
     StopRequestState.NOT_SENT,
-    new Tag(TimeValue.FOREVER(), 0)
+    new Tag(TimeValue.forever(), 0)
   );
 
   /**
@@ -1133,7 +1133,7 @@ export class FederatedApp extends App {
    * An RTI synchronized Federate cannot advance its logical time
    * beyond this value.
    */
-  private greatestTimeAdvanceGrant: Tag = new Tag(TimeValue.NEVER(), 0);
+  private greatestTimeAdvanceGrant: Tag = new Tag(TimeValue.never(), 0);
 
   private readonly upstreamFedIDs: number[] = [];
 
@@ -1221,7 +1221,7 @@ export class FederatedApp extends App {
    * @param nextEvent
    */
   protected _canProceed(nextEvent: TaggedEvent<unknown>): boolean {
-    let tagBarrier = new Tag(TimeValue.NEVER());
+    let tagBarrier = new Tag(TimeValue.never());
     // Set tag barrier using the tag when stop is requested but not granted yet.
     // Otherwise, set the tagBarrier using the greated TAG.
     if (this.stopRequestInfo.state === StopRequestState.SENT) {
@@ -1362,7 +1362,7 @@ export class FederatedApp extends App {
       );
     }
     for (let index = 0; index < config.dependsOn.length; index++) {
-      let minOutputConnectionDelay = TimeValue.FOREVER();
+      let minOutputConnectionDelay = TimeValue.forever();
       for (const candidate of config.upstreamConnectionDelays[index]) {
         if (minOutputConnectionDelay.isLaterThan(candidate)) {
           minOutputConnectionDelay = candidate;

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -89,8 +89,7 @@ interface IOPortManager<T> extends TriggerManager {
   // However, this indicates that there are typing issues and needs to be addressed.
   // eslint-disable-next-line @typescript-eslint/method-signature-style
   addReceiver(port: WritablePort<T>): void;
-  // eslint-disable-next-line @typescript-eslint/method-signature-style
-  delReceiver(port: WritablePort<T>): void;
+  delReceiver: (port: WritablePort<T>) => void;
 }
 
 export abstract class IOPort<T> extends Port<T> {

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -83,8 +83,11 @@ export abstract class WritableMultiPort<T> implements MultiReadWrite<T> {
  * Interface for a writable multi port, intended as a wrapper for a multi port.
  */
 interface IOPortManager<T> extends TriggerManager {
-  addReceiver: (port: WritablePort<T>) => void;
-  delReceiver: (port: WritablePort<T>) => void;
+  // See https://github.com/lf-lang/reactor-ts/issues/184
+  // eslint-disable-next-line @typescript-eslint/method-signature-style 
+  addReceiver(port: WritablePort<T>): void;
+  // eslint-disable-next-line @typescript-eslint/method-signature-style 
+  delReceiver(port: WritablePort<T>): void;
 }
 
 export abstract class IOPort<T> extends Port<T> {

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -83,12 +83,7 @@ export abstract class WritableMultiPort<T> implements MultiReadWrite<T> {
  * Interface for a writable multi port, intended as a wrapper for a multi port.
  */
 interface IOPortManager<T> extends TriggerManager {
-  // TODO (axmmisaka): Function property is better in terms of type checking
-  // as tsc will check additional info; yet that additional check will cause massive issues
-  // and therefore this linter rule is disabled and method signature is used.
-  // However, this indicates that there are typing issues and needs to be addressed.
-  // eslint-disable-next-line @typescript-eslint/method-signature-style
-  addReceiver(port: WritablePort<T>): void;
+  addReceiver: (port: WritablePort<T>) => void;
   delReceiver: (port: WritablePort<T>) => void;
 }
 

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -84,9 +84,9 @@ export abstract class WritableMultiPort<T> implements MultiReadWrite<T> {
  */
 interface IOPortManager<T> extends TriggerManager {
   // See https://github.com/lf-lang/reactor-ts/issues/184
-  // eslint-disable-next-line @typescript-eslint/method-signature-style 
+  // eslint-disable-next-line @typescript-eslint/method-signature-style
   addReceiver(port: WritablePort<T>): void;
-  // eslint-disable-next-line @typescript-eslint/method-signature-style 
+  // eslint-disable-next-line @typescript-eslint/method-signature-style
   delReceiver(port: WritablePort<T>): void;
 }
 

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -1222,7 +1222,9 @@ export abstract class Reactor extends Component {
     this._dependencyGraph.addEdge(src, dst);
     // Register receiver for value propagation.
     const writer = dst.asWritable(this._getKey(dst));
-    src.getManager(this._getKey(src)).addReceiver(writer as unknown as WritablePort<S>);
+    src
+      .getManager(this._getKey(src))
+      .addReceiver(writer as unknown as WritablePort<S>);
     const val = src.get();
     if (this._runtime.isRunning() && val !== undefined) {
       writer.set(val);
@@ -1322,7 +1324,8 @@ export abstract class Reactor extends Component {
 
   protected _connectCall<A extends T, R, T, S extends R>(
     src: CallerPort<A, R>,
-    dst: CalleePort<T, S>): void {
+    dst: CalleePort<T, S>
+  ): void {
     if (this.canConnectCall(src, dst)) {
       Log.debug(this, () => `connecting ${src} and ${dst}`);
       // Treat connections between callers and callees separately.
@@ -1455,7 +1458,7 @@ export abstract class Reactor extends Component {
    * @param src Source port of connection to be disconnected.
    * @param dst Destination port of connection to be disconnected. If undefined, disconnect all connections from the source port.
    */
-  protected  _disconnect<R, S extends R>(src: IOPort<S>, dst?: IOPort<R>): void {
+  protected _disconnect<R, S extends R>(src: IOPort<S>, dst?: IOPort<R>): void {
     if (
       (!this._runtime.isRunning() && this._isInScope(src, dst)) ||
       this._runtime.isRunning()
@@ -1480,9 +1483,7 @@ export abstract class Reactor extends Component {
       for (const node of nodes) {
         if (node instanceof IOPort) {
           const writer = node.asWritable(this._getKey(node));
-          src
-            .getManager(this._getKey(src))
-            .delReceiver(writer);
+          src.getManager(this._getKey(src)).delReceiver(writer);
           this._dependencyGraph.removeEdge(src, node);
         }
       }

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -578,7 +578,6 @@ export abstract class Reactor extends Component {
     return action.asSchedulable(this._getKey(action));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private _recordDeps<T extends Variable[]>(reaction: Reaction<T>): void {
     // Add a dependency on the previous reaction or mutation, if it exists.
     const prev = this._getLastReactionOrMutation();
@@ -1618,8 +1617,7 @@ export class CallerPort<A, R> extends Port<R> implements Write<A>, Read<R> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-interface CalleeManager<T> extends TriggerManager {
+interface CalleeManager extends TriggerManager {
   setLastCaller: (reaction: Reaction<Variable[]> | undefined) => void;
   getLastCaller: () => Reaction<Variable[]> | undefined;
   addReaction: (procedure: Procedure<Variable[]>) => void;
@@ -1663,14 +1661,14 @@ export class CalleePort<A, R> extends Port<A> implements Read<A>, Write<R> {
    *
    * @param key
    */
-  public getManager(key: symbol | undefined): CalleeManager<A> {
+  public getManager(key: symbol | undefined): CalleeManager {
     if (this._key === key) {
       return this.manager;
     }
     throw Error("Unable to grant access to manager.");
   }
 
-  protected manager: CalleeManager<A> = new (class implements CalleeManager<A> {
+  protected manager: CalleeManager = new (class implements CalleeManager {
     constructor(private readonly port: CalleePort<A, unknown>) {}
 
     getContainer(): Reactor {

--- a/src/core/strings.ts
+++ b/src/core/strings.ts
@@ -1,31 +1,8 @@
-// TODO (axmmisaka): find a way to address these issues
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /**
- * Utility class for handling strings, for example, to format diagraph
- * string representation.
+ * Remove indentation in the multi-line string.
+ * @param template Multi-line string whose indentation should be removed.
+ * @returns String without indentation.
  */
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class StringUtil {
-  /**
-   * Remove indentation in the multi-line string.
-   * @param template Multi-line string whose indentation should be removed.
-   * @returns String without indentation.
-   */
-  public static dontIndent(template: TemplateStringsArray): string {
-    return ("" + template.toString()).replace(/(\n)\s+/g, "$1");
-  }
-
-  public static toRegex(template: TemplateStringsArray, ...keys: any[]) {
-    return function (...values: any[]) {
-      const dict = values[values.length - 1] ?? {};
-      const result = [template[0]];
-      keys.forEach(function (key, i) {
-        const value = Number.isInteger(key) ? values[key] : dict[key];
-        result.push(value, template[i + 1]);
-      });
-      return result.join("").replace(/(\n)\s+/g, "$1");
-    };
-  }
+export function dontIndent(template: TemplateStringsArray): string {
+  return ("" + template.toString()).replace(/(\n)\s+/g, "$1");
 }

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -62,15 +62,11 @@ export class TimeValue {
     return new TimeValue(0, 0);
   }
 
-  // The symbles "NEVER" and "FOREVER" are used in `lingua-franca` main codebase,
-  // so it does not make much sense to lint them or warn against.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  static NEVER(): TimeValue {
+  static never(): TimeValue {
     return new TimeValue(Number.MIN_SAFE_INTEGER, 0);
   }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  static FOREVER(): TimeValue {
+  static forever(): TimeValue {
     return new TimeValue(Number.MAX_SAFE_INTEGER, 0);
   }
 
@@ -305,9 +301,9 @@ export class TimeValue {
     // To avoid overflow and floating point errors, work with BigInts.
     const bigTime = buffer.readBigUInt64LE(0);
     if (bigTime === BigInt(0x8000000000000000n)) {
-      return TimeValue.NEVER();
+      return TimeValue.never();
     } else if (bigTime === BigInt(0x7fffffffffffffffn)) {
-      return TimeValue.FOREVER();
+      return TimeValue.forever();
     }
 
     const bigSeconds = bigTime / billion;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,6 +77,12 @@ export type Absent = undefined;
  */
 export type ArgList<T> = T extends Variable[] ? T : never;
 
+/**
+ * Type that describes a tuple of parameters passed into the constructor
+ * of a reactor class.
+ */
+export type ParmList<T> = T extends unknown[] ? T : never;
+
 export interface Sortable<P> {
   setPriority: (priority: P) => void;
 

--- a/src/share/Logger.ts
+++ b/src/share/Logger.ts
@@ -24,7 +24,7 @@ function print(
 }
 
 export class Logger extends Reactor {
-  i = new InPort(this);
+  i = new InPort<string>(this);
 
   constructor(parent: Reactor, expected: unknown) {
     super(parent);


### PR DESCRIPTION
- [x] remove usages of `any`
- [x] rename `FOREVER()` and `NEVER()` (also in `lingua-franca`)
- [x] ~~`port.ts:90` and `port.ts:93`~~ see #184 
- [x] `reactor.ts:581` and `reactor.ts:1622`

Fixes  #162.
