### PR TITLE
Draft: Add a special class for network receiver and sender reactors

### DIFF
--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -290,6 +290,7 @@ export class NetworkReactor extends Reactor {
   // TpoLevel of this NetworkReactor
   private TpoLevel: number;
 
+  // Fixme: How to use the appropriate type instead of 'unknown'?
   private networkInputAction: FederatePortAction<unknown> = new FederatePortAction(this, Origin.logical);
 
   private readonly portID: number;
@@ -1636,6 +1637,13 @@ export class FederatedApp extends App {
   }
 
   /**
+   * 
+   */
+  _addEdgesForTpoLevels():void {
+    // Fixme: Add edges for TPO levels by looking tpo levels of network reactors
+  }
+
+  /**
    * @override
    * Register this federated app with the RTI and request a start time.
    * This function registers handlers for the events produced by the federated app's
@@ -1644,6 +1652,8 @@ export class FederatedApp extends App {
    * time message from the RTI.
    */
   _start(): void {
+    this._addEdgesForTpoLevels();
+    
     this._analyzeDependencies();
 
     this._loadStartupReactions();

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -287,8 +287,8 @@ function isANodeJSCodedError(e: Error): e is NodeJSCodedError {
  * A network reactor is a reactor handling network actions (NetworkReciever and NetworkSender).
  */
 export class NetworkReactor extends Reactor {
-  // TpoLevel of this NetworkReactor
-  private TpoLevel: number;
+  // TPO level of this NetworkReactor
+  private readonly tpoLevel: number;
 
   // Fixme: How to use the appropriate type instead of 'unknown'?
   private networkInputAction: FederatePortAction<unknown> = new FederatePortAction(this, Origin.logical);
@@ -298,22 +298,22 @@ export class NetworkReactor extends Reactor {
   constructor (
       parent: Reactor,
       portID: number,
-      TpoLevel: number
+      tpoLevel: number
   ) {
     super(parent);
     this.portID = portID;
-    this.TpoLevel = TpoLevel;
+    this.tpoLevel = tpoLevel;
   }
 
-  public getTpoLevel() {
-    return this.TpoLevel;
+  public getTpoLevel(): number {
+    return this.tpoLevel;
   }
 
-  public getPortID() {
+  public getPortID(): number {
     return this.portID;
   }
 
-  public registerNetworkInputAction(networkInputAction: FederatePortAction<unknown>) {
+  public registerNetworkInputAction(networkInputAction: FederatePortAction<unknown>): void {
     this.networkInputAction = networkInputAction;
   }
 
@@ -333,7 +333,7 @@ export class NetworkReactor extends Reactor {
   ):void {
     if (this.networkInputAction.origin === Origin.logical) {
       this.networkInputAction
-        //FIXME: Is this a right way to trigger a federatePortAction in the NetworkReceiver reactor?
+        // FIXME: Is this a right way to trigger a federatePortAction in the NetworkReceiver reactor?
         .asSchedulable(this._getKey(this.networkInputAction))
         .schedule(0, value, intendedTag);
     } else {
@@ -982,7 +982,7 @@ class RTIClient extends EventEmitter {
                 bufferIndex + 21,
                 bufferIndex + 21 + messageLength
               );
-              //const destPort = this.federatePortActionByID.get(destPortID);
+              // const destPort = this.federatePortActionByID.get(destPortID);
               this.emit("timedMessage", destPortID, messageBuffer, tag);
             }
 
@@ -1186,7 +1186,7 @@ export class FederatedApp extends App {
   /**
    * An array of network receivers
    */
-  private networkRecievers: Array<NetworkReactor> = [];
+  private networkRecievers: NetworkReactor[] = [];
 
   /**
    * Stop request-related information

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -11,7 +11,8 @@ import {
   Alarm,
   App,
   TaggedEvent,
-  FederatePortAction
+  FederatePortAction,
+  Reactor
 } from "./internal";
 
 // ---------------------------------------------------------------------//
@@ -283,6 +284,68 @@ function isANodeJSCodedError(e: Error): e is NodeJSCodedError {
 }
 
 /**
+ * A network reactor is a reactor handling network actions (NetworkReciever and NetworkSender).
+ */
+export class NetworkReactor extends Reactor {
+  // TpoLevel of this NetworkReactor
+  private TpoLevel: number;
+
+  private networkInputAction: FederatePortAction<unknown> = new FederatePortAction(this, Origin.logical);
+
+  private readonly portID: number;
+
+  constructor (
+      parent: Reactor,
+      portID: number,
+      TpoLevel: number
+  ) {
+    super(parent);
+    this.portID = portID;
+    this.TpoLevel = TpoLevel;
+  }
+
+  public getTpoLevel() {
+    return this.TpoLevel;
+  }
+
+  public getPortID() {
+    return this.portID;
+  }
+
+  public registerNetworkInputAction(networkInputAction: FederatePortAction<unknown>) {
+    this.networkInputAction = networkInputAction;
+  }
+
+  public handlingMessage<T>(
+    portID: number,
+    value: T
+  ):void {
+    this.networkInputAction
+      .asSchedulable(this._getKey(this.networkInputAction))
+      .schedule(0, value);
+}
+
+  public handlingTimedMessage<T>(
+    portID: number,
+    value: T,
+    intendedTag: Tag
+  ):void {
+    if (this.networkInputAction.origin === Origin.logical) {
+      this.networkInputAction
+        //FIXME: Is this a right way to trigger a federatePortAction in the NetworkReceiver reactor?
+        .asSchedulable(this._getKey(this.networkInputAction))
+        .schedule(0, value, intendedTag);
+    } else {
+      // The schedule function for physical actions implements
+      // Tr = max(r, R + A)
+      this.networkInputAction
+        .asSchedulable(this._getKey(this.networkInputAction))
+        .schedule(0, value);
+    }
+  }
+}
+
+/**
  * An RTIClient is used within a federate to abstract the socket
  * connection to the RTI and the RTI's binary protocol over the socket.
  * RTIClient exposes functions for federate-level operations like
@@ -313,20 +376,20 @@ class RTIClient extends EventEmitter {
   private readonly federatePortActionByID: Map<number, Action<unknown>> =
     new Map<number, Action<unknown>>();
 
-  /**
-   * Establish the mapping between a federate port's action and its ID.
-   * @param federatePortID The federate port's ID.
-   * @param federatePort The federate port's action.
-   */
-  public registerFederatePortAction<T>(
-    federatePortID: number,
-    federatePortAction: Action<T>
-  ): void {
-    this.federatePortActionByID.set(
-      federatePortID,
-      federatePortAction as Action<unknown>
-    );
-  }
+  // /**
+  //  * Establish the mapping between a federate port's action and its ID.
+  //  * @param federatePortID The federate port's ID.
+  //  * @param federatePort The federate port's action.
+  //  */
+  // public registerFederatePortAction<T>(
+  //   federatePortID: number,
+  //   federatePortAction: Action<T>
+  // ): void {
+  //   this.federatePortActionByID.set(
+  //     federatePortID,
+  //     federatePortAction as Action<unknown>
+  //   );
+  // }
 
   /**
    * Constructor for an RTIClient
@@ -860,9 +923,9 @@ class RTIClient extends EventEmitter {
                 bufferIndex + 9,
                 bufferIndex + 9 + messageLength
               );
-              const destPortAction =
-                this.federatePortActionByID.get(destPortID);
-              this.emit("message", destPortAction, messageBuffer);
+              // const destPort =
+              //   this.federatePortActionByID.get(destPortID);
+              this.emit("message", destPortID, messageBuffer);
             }
 
             bufferIndex += messageLength + 9;
@@ -918,8 +981,8 @@ class RTIClient extends EventEmitter {
                 bufferIndex + 21,
                 bufferIndex + 21 + messageLength
               );
-              const destPort = this.federatePortActionByID.get(destPortID);
-              this.emit("timedMessage", destPort, messageBuffer, tag);
+              //const destPort = this.federatePortActionByID.get(destPortID);
+              this.emit("timedMessage", destPortID, messageBuffer, tag);
             }
 
             bufferIndex += messageLength + 21;
@@ -1120,6 +1183,11 @@ export class FederatedApp extends App {
   private readonly rtiClient: RTIClient;
 
   /**
+   * An array of network receivers
+   */
+  private networkRecievers: Array<NetworkReactor> = [];
+
+  /**
    * Stop request-related information
    * including the current state and the tag associated with the stop requested or stop granted.
    */
@@ -1142,7 +1210,7 @@ export class FederatedApp extends App {
 
   private readonly downstreamFedIDs: number[] = [];
 
-  private readonly outputControlReactionTriggers: Array<Action<unknown>> = [];
+  // private readonly outputControlReactionTriggers: Array<Action<unknown>> = [];
 
   /**
    * The default value, null, indicates there is no output depending on a physical action.
@@ -1169,11 +1237,11 @@ export class FederatedApp extends App {
     this.minDelayFromPhysicalActionToFederateOutput = minDelay;
   }
 
-  public registerOutputControlReactionTrigger(
-    outputControlReactionTrigger: Action<unknown>
-  ): void {
-    this.outputControlReactionTriggers.push(outputControlReactionTrigger);
-  }
+  // public registerOutputControlReactionTrigger(
+  //   outputControlReactionTrigger: Action<unknown>
+  // ): void {
+  //   this.outputControlReactionTriggers.push(outputControlReactionTrigger);
+  // }
 
   /**
    * Getter for greatestTimeAdvanceGrant
@@ -1378,36 +1446,42 @@ export class FederatedApp extends App {
     }
   }
 
-  /**
-   * Register a federate port's action with the federate. It must be registered
-   * so it is known by the rtiClient and may be scheduled when a message for the
-   * port has been received via the RTI.
-   * @param federatePortID The designated ID for the federate port. For compatability with the
-   * C RTI, the ID must be expressable as a 16 bit unsigned short. The ID must be
-   * unique among all port IDs on this federate and be a number between 0 and NUMBER_OF_PORTS - 1
-   * @param federatePort The federate port's action for registration.
-   */
-  public registerFederatePortAction<T>(
-    federatePortID: number,
-    federatePortAction: Action<T>
+  // /**
+  //  * Register a federate port's action with the federate. It must be registered
+  //  * so it is known by the rtiClient and may be scheduled when a message for the
+  //  * port has been received via the RTI.
+  //  * @param federatePortID The designated ID for the federate port. For compatability with the
+  //  * C RTI, the ID must be expressable as a 16 bit unsigned short. The ID must be
+  //  * unique among all port IDs on this federate and be a number between 0 and NUMBER_OF_PORTS - 1
+  //  * @param federatePort The federate port's action for registration.
+  //  */
+  // public registerFederatePortAction<T>(
+  //   federatePortID: number,
+  //   federatePortAction: Action<T>
+  // ): void {
+  //   this.rtiClient.registerFederatePortAction(
+  //     federatePortID,
+  //     federatePortAction
+  //   );
+  // }
+
+  public registerNetworkReciever(
+    networkReciever: NetworkReactor
   ): void {
-    this.rtiClient.registerFederatePortAction(
-      federatePortID,
-      federatePortAction
-    );
+    this.networkRecievers.push(networkReciever)
   }
 
-  private _getFederatePortActionKey<T>(federatePortAction: FederatePortAction<T>): symbol | undefined {
-    if (
-      (federatePortAction instanceof FederatePortAction) &&
-      federatePortAction._isContainedByContainerOf(this)
-    ) {
-      const owner = federatePortAction.getContainer();
-      if (owner !== null) {
-        return owner._getKey(federatePortAction, this._keyChain.get(owner));
-      }
-    }
-  }
+  // private _getFederatePortActionKey<T>(federatePortAction: FederatePortAction<T>): symbol | undefined {
+  //   if (
+  //     (federatePortAction instanceof FederatePortAction) &&
+  //     federatePortAction._isContainedByContainerOf(this)
+  //   ) {
+  //     const owner = federatePortAction.getContainer();
+  //     if (owner !== null) {
+  //       return owner._getKey(federatePortAction, this._keyChain.get(owner));
+  //     }
+  //   }
+  // }
 
   /**
    * Send a message to a potentially remote federate's port via the RTI. This message
@@ -1612,7 +1686,7 @@ export class FederatedApp extends App {
 
     this.rtiClient.on(
       "message",
-      <T>(destPortAction: Action<T>, messageBuffer: Buffer) => {
+      <T>(destPortID: number, messageBuffer: Buffer) => {
         // Schedule this federate port's action.
         // This message is untimed, so schedule it immediately.
         Log.debug(this, () => {
@@ -1622,15 +1696,21 @@ export class FederatedApp extends App {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const value: T = JSON.parse(messageBuffer.toString());
 
-        destPortAction
-          .asSchedulable(this._getFederatePortActionKey(destPortAction))
-          .schedule(0, value);
+        for (let candidate of this.networkRecievers) {
+          if (candidate.getPortID() === destPortID) {
+            candidate.handlingMessage<T>(destPortID, value);
+          }
+        }
+
+        // destPortAction
+        //   .asSchedulable(this._getFederatePortActionKey(destPortAction))
+        //   .schedule(0, value);
       }
     );
 
     this.rtiClient.on(
       "timedMessage",
-      <T>(destPortAction: Action<T>, messageBuffer: Buffer, tag: Tag) => {
+      <T>(destPortID: number, messageBuffer: Buffer, tag: Tag) => {
         // Schedule this federate port's action.
 
         /**
@@ -1659,18 +1739,24 @@ export class FederatedApp extends App {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const value: T = JSON.parse(messageBuffer.toString());
 
-        if (destPortAction.origin === Origin.logical) {
-          destPortAction
-            //FIXME: Is this a right way to trigger a federatePortAction in the NetworkReceiver reactor?
-            .asSchedulable(this._getFederatePortActionKey(destPortAction))
-            .schedule(0, value, tag);
-        } else {
-          // The schedule function for physical actions implements
-          // Tr = max(r, R + A)
-          destPortAction
-            .asSchedulable(this._getFederatePortActionKey(destPortAction))
-            .schedule(0, value);
+        for (let candidate of this.networkRecievers) {
+          if (candidate.getPortID() === destPortID) {
+            candidate.handlingTimedMessage<T>(destPortID, value, tag);
+          }
         }
+
+        // if (destPortAction.origin === Origin.logical) {
+        //   destPortAction
+        //     //FIXME: Is this a right way to trigger a federatePortAction in the NetworkReceiver reactor?
+        //     .asSchedulable(this._getFederatePortActionKey(destPortAction))
+        //     .schedule(0, value, tag);
+        // } else {
+        //   // The schedule function for physical actions implements
+        //   // Tr = max(r, R + A)
+        //   destPortAction
+        //     .asSchedulable(this._getFederatePortActionKey(destPortAction))
+        //     .schedule(0, value);
+        // }
       }
     );
 

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1357,7 +1357,6 @@ export class FederatedApp extends App {
   }
 
   protected _iterationComplete(): void {
-    this.executeOutputControlReactions();
     const currentTime = this.util.getCurrentTag();
     this.sendRTILogicalTimeComplete(currentTime);
   }
@@ -1512,9 +1511,9 @@ export class FederatedApp extends App {
       }
   }
 
-  protected executeOutputControlReactions(): void {
+  protected enqueueOutputControlReactions(): void {
     this.outputControlReactions.forEach(reaction => {
-      reaction.doReact();
+      this._reactionQ.push(reaction);
     });
   }
 

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1195,15 +1195,15 @@ export class FederatedApp extends App {
 
   /**
    * An array of network receivers
-   */
-  private readonly networkRecievers: NetworkReactor[] = [];
+   */ 
+  private readonly networkReceivers: NetworkReactor[] = [];
 
   /**
    * An array of network senders
    */
   private readonly networkSenders: NetworkReactor[] = [];
 
-  private readonly outputControlReactions = new Set<Reaction<Variable[]>>();
+  private readonly portAbsentReactions = new Set<Reaction<Variable[]>>();
 
   /**
    * Stop request-related information
@@ -1490,7 +1490,7 @@ export class FederatedApp extends App {
   public registerNetworkReciever(
     networkReciever: NetworkReactor
   ): void {
-    this.networkRecievers.push(networkReciever);
+    this.networkReceivers.push(networkReciever);
   }
 
   /**
@@ -1510,13 +1510,13 @@ export class FederatedApp extends App {
       for (const networkSender of this.networkSenders) {
         const lastReactionOrMutation = networkSender.getLastReactioOrMutation();
         if (lastReactionOrMutation !== undefined) {
-          this.outputControlReactions.add(lastReactionOrMutation);
+          this.portAbsentReactions.add(lastReactionOrMutation);
         }
       }
   }
 
   protected enqueueOutputControlReactions(): void {
-    this.outputControlReactions.forEach(reaction => {
+    this.portAbsentReactions.forEach(reaction => {
       this._reactionQ.push(reaction);
     });
   }
@@ -1689,7 +1689,7 @@ export class FederatedApp extends App {
    * 
    */
   _addEdgesForTpoLevels():void {
-    let networkReactors = this.networkRecievers.concat(this.networkSenders);
+    let networkReactors = this.networkReceivers.concat(this.networkSenders);
     networkReactors.sort((a: NetworkReactor, b: NetworkReactor): number => {
       return a.getTpoLevel() - b.getTpoLevel();
     })
@@ -1766,7 +1766,7 @@ export class FederatedApp extends App {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const value: T = JSON.parse(messageBuffer.toString());
 
-        for (const candidate of this.networkRecievers) {
+        for (const candidate of this.networkReceivers) {
           if (candidate.getPortID() === destPortID) {
             candidate.handlingMessage<T>(destPortID, value);
           }
@@ -1809,7 +1809,7 @@ export class FederatedApp extends App {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const value: T = JSON.parse(messageBuffer.toString());
 
-        for (let candidate of this.networkRecievers) {
+        for (let candidate of this.networkReceivers) {
           if (candidate.getPortID() === destPortID) {
             candidate.handlingTimedMessage<T>(destPortID, value, tag);
           }

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -784,7 +784,6 @@ export abstract class Reactor extends Component {
     trigs: Variable[],
     args: [...ArgList<T>],
     react: (this: ReactionSandbox, ...args: ArgList<T>) => void,
-    level?: Number,
     deadline?: TimeValue,
     late: (this: ReactionSandbox, ...args: ArgList<T>) => void = () => {
       Log.global.warn("Deadline violation occurred!");
@@ -1917,6 +1916,12 @@ export class App extends Reactor {
     ): void {
       this.app.sendRTIPortAbsent(additionalDelay, destFederateID, destPortID);
     }
+
+    public registerOutputControlReactions(
+
+    ): void {
+      this.app.registerOutputControlReactions();
+    }
   })(this);
 
   /**
@@ -2098,6 +2103,14 @@ export class App extends Reactor {
   ): void {
     throw new Error(
       "Cannot call sendRTIPortAbsent from an App. sendRTIPortAbsent may be called only from a FederatedApp"
+    );
+  }
+
+  protected registerOutputControlReactions(
+    
+  ): void {
+    throw new Error(
+      "Cannot call registerOutputControlReactions from an App. registerOutputControlReactions may be called only from a FederatedApp"
     );
   }
 

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -2158,7 +2158,7 @@ export class App extends Reactor {
   /**
    * Priority set that keeps track of reactions at the current Logical time.
    */
-  private readonly _reactionQ = new ReactionQueue();
+  protected readonly _reactionQ = new ReactionQueue();
 
   /**
    * The physical time when execution began relative to January 1, 1970 00:00:00 UTC.
@@ -2298,9 +2298,7 @@ export class App extends Reactor {
     Log.global.debug("Finished handling all events at current time.");
   }
 
-  // protected enqueueNetworkOutputControlReactions(): void {
-  //   return undefined;
-  // }
+  protected enqueueOutputControlReactions(): void { }
 
   /**
    * Handle the next events on the event queue.
@@ -2399,8 +2397,8 @@ export class App extends Reactor {
         nextEvent != null &&
         this._currentTag.isSimultaneousWith(nextEvent.tag)
       );
-      // // enqueue networkOutputControlReactions
-      // this.enqueueNetworkOutputControlReactions();
+      // enqueue networkOutputControlReactions
+      this.enqueueOutputControlReactions();
 
       // React to all the events loaded onto the reaction queue.
       this._react();
@@ -2683,7 +2681,7 @@ export class App extends Reactor {
     Log.info(this, () => `>>> Start of execution: ${this._currentTag}`);
     Log.info(this, () => Log.hr);
     // enqueue networkOutputControlReactions
-    // this.enqueueNetworkOutputControlReactions();
+    this.enqueueOutputControlReactions();
 
     // Handle the reactions that were loaded onto the reaction queue.
     this._react();

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -152,7 +152,7 @@ export abstract class Reactor extends Component {
    * Note: declare this class member before any other ones as they may
    * attempt to access it.
    */
-  protected readonly _keyChain = new Map<Component, symbol>();
+  private readonly _keyChain = new Map<Component, symbol>();
 
   /**
    * This graph has in it all the dependencies implied by this container's


### PR DESCRIPTION
This PR adds a special class for the federated execution as network actions are managed by each network reactor, not the top-level federated reactor. The name of the class is `NetworkReactor` instead of `FederatedReactor` because they are not federated and are used for processing network actions.