### PR TITLE
Use dependabot grouping feature to make sure it doesn't make 1000 PRs every day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+


### PR DESCRIPTION
It is a beta feature in public beta released a month ago, which is something we desperately need.
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Demo: https://github.com/axmmisaka/reactor-ts/pull/21