### PR TITLE
Bugfix: use copy of set in PrecedenceGraph::addAll

### DIFF
--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -36,7 +36,7 @@ export class PrecedenceGraph<T> {
           }
         }
       } else {
-        this.adjacencyMap.set(k, v);
+        this.adjacencyMap.set(k, new Set(v));
         this.numberOfEdges += v.size;
       }
     }


### PR DESCRIPTION
Originally, `PrecedenceGraph::addAll` might accidentally assign a reference to a set denoting edges instead of copying that set. This has caused unintended side effects and weird behaviours in `mutation/savina-quicksort`. This PR fixes the problem.