### PR TITLE
Draft: Adjusting access to utils for federated execution

### DIFF
--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -7,7 +7,8 @@ import type {
   Reaction,
   Variable,
   TaggedEvent,
-  SchedulableAction
+  SchedulableAction,
+  UtilityFunctions
 } from "./internal";
 import {
   Log,
@@ -1183,6 +1184,24 @@ class RTIClient extends EventEmitter {
       return "exiting handleSocketData";
     });
   }
+}
+interface FedreateUtilityFunctions extends UtilityFunctions {
+  sendRTIMessage: <T>(
+    data: T,
+    destFederateID: number,
+    destPortID: number
+  ) => void;
+  sendRTITimedMessage: <T>(
+    data: T,
+    destFederateID: number,
+    destPortID: number,
+    time: TimeValue | undefined
+  ) => void;
+  sendRTIPortAbsent: (
+    destFederateID: number,
+    destPortID: number,
+    additionalDelay: TimeValue | undefined
+  ) => void;
 }
 
 /**

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -1753,7 +1753,7 @@ export interface Runtime {
   delete: (r: Reactor) => void;
   isRunning: () => boolean;
 }
-interface UtilityFunctions {
+export interface UtilityFunctions {
   requestStop: () => void;
   reportError: (message?: string) => void;
   requestErrorStop: (message?: string) => void;


### PR DESCRIPTION
Fixes https://github.com/lf-lang/reactor-ts/issues/112. 

This PR is still working on progress. The purpose of the work is to remove functionalities for federated execution from `reactor.ts` and add them to `federation.ts`. 