### PR TITLE
Fix Online Facility Location

### DIFF
--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -475,6 +475,20 @@ export abstract class Reactor extends Component {
     public delete(reactor: Reactor): void {
       reactor._delete();
     }
+
+    public addChild<R extends Reactor, G extends unknown[]>(
+      constructor: new (container: Reactor, ...args: G) => R,
+      ...args: G
+    ): R {
+      return this.reactor._addChild(constructor, ...args);
+    }
+
+    public addSibling<R extends Reactor, G extends unknown[]>(
+      constructor: new (container: Reactor, ...args: G) => R,
+      ...args: G
+    ): R {
+      return this.reactor._addSibling(constructor, ...args);
+    }
   };
 
   /**
@@ -1586,10 +1600,7 @@ export abstract class Reactor extends Component {
         `Reactor ${this} is self-contained. Adding sibling creates logical issue.`
       );
     }
-    const newReactor = this._getContainer()._addChild(
-      constructor,
-      ...args
-    );
+    const newReactor = this._getContainer()._addChild(constructor, ...args);
     this._creatorKeyChain.set(newReactor, newReactor._key);
     return newReactor;
   }
@@ -1832,6 +1843,16 @@ export interface MutationSandbox extends ReactionSandbox {
   delete: (reactor: Reactor) => void;
 
   getReactor: () => Reactor; // Container
+
+  addChild: <R extends Reactor, G extends unknown[]>(
+    constructor: new (container: Reactor, ...args: G) => R,
+    ...args: G
+  ) => R;
+
+  addSibling: <R extends Reactor, G extends unknown[]>(
+    constructor: new (container: Reactor, ...args: G) => R,
+    ...args: G
+  ) => R;
 
   // FIXME:
   // forkJoin(constructor: new () => Reactor, ): void;

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -153,6 +153,11 @@ export abstract class Reactor extends Component {
    */
   private readonly _keyChain = new Map<Component, symbol>();
 
+  // This is the keychain for creation, i.e. if Reactor R's mutation created reactor B,
+  // then R is B's creator, even if they are siblings. R should have access to B,
+  // at least semantically......?
+  private readonly _creatorKeyChain = new Map<Component, symbol>();
+
   /**
    * This graph has in it all the dependencies implied by this container's
    * ports, reactions, and connections.
@@ -387,6 +392,9 @@ export abstract class Reactor extends Component {
         return owner._getKey(component, this._keyChain.get(owner));
       }
     }
+    return component
+      .getContainer()
+      ._getKey(component, this._creatorKeyChain.get(component.getContainer()));
   }
 
   /**
@@ -1554,6 +1562,36 @@ export abstract class Reactor extends Component {
    */
   toString(): string {
     return this._getFullyQualifiedName();
+  }
+
+  protected _addChild<R extends Reactor, G extends unknown[]>(
+    constructor: new (container: Reactor, ...args: G) => R,
+    ...args: G
+  ): R {
+    const newReactor = new constructor(this, ...args);
+    return newReactor;
+  }
+
+  protected _addSibling<R extends Reactor, G extends unknown[]>(
+    constructor: new (container: Reactor, ...args: G) => R,
+    ...args: G
+  ): R {
+    if (this._getContainer() == null) {
+      throw new Error(
+        `Reactor ${this} does not have a parent. Sibling is not well-defined.`
+      );
+    }
+    if (this._getContainer() === this) {
+      throw new Error(
+        `Reactor ${this} is self-contained. Adding sibling creates logical issue.`
+      );
+    }
+    const newReactor = this._getContainer()._addChild(
+      constructor,
+      ...args
+    );
+    this._creatorKeyChain.set(newReactor, newReactor._key);
+    return newReactor;
   }
 }
 


### PR DESCRIPTION
## Action item
- [ ] Verify that this modification is correct and fits the original intention when Prof. Dr. @hokeun wrote it

## Problem 

Sorry for my delayed reply.

In the original code, in `Quadrant`'s second mutation, `toAccumulator` (an `OutPort`) was the destination of two components:
`toNextAccumulator` of `Accumulator`:
https://github.com/lf-lang/reactor-ts/blob/b81e1ce9214835d8e3197af1f2d4b4c7b9cac927/src/benchmark/FacilityLocation.ts#L625-L629

and the mutation (`[M1]` itself:
https://github.com/lf-lang/reactor-ts/blob/b81e1ce9214835d8e3197af1f2d4b4c7b9cac927/src/benchmark/FacilityLocation.ts#L757-L763

I suppose, effectively, the first connection (which doesn't make much sense in the first place as it was connecting an `OutPort` to an `OutPort`), is to make a logic that "once `toNextAccumulator` is set, we also set `toAccumulator`"

My current ugly fix is simply replicate this logic without making any additional connection by accessing a parent port from children: in `Accumulator`:

https://github.com/lf-lang/reactor-ts/blob/82d6e34885f476befcdb9d30ab7ebb546ff4e8a8/src/benchmark/FacilityLocation.ts#L300-L313

Then set both ports when one needs to be updated:
https://github.com/lf-lang/reactor-ts/blob/82d6e34885f476befcdb9d30ab7ebb546ff4e8a8/src/benchmark/FacilityLocation.ts#L359-L374

I suppose this is not a good way to do it...... So I'm all ears

_Originally posted by @axmmisaka in https://github.com/lf-lang/reactor-ts/issues/223#issuecomment-1701992639_