### PR TITLE
Refactor Reactor::{connect, connectMulti, canConnect}

### DIFF
--- a/__tests__/HierarchicalSingleEvent.test.ts
+++ b/__tests__/HierarchicalSingleEvent.test.ts
@@ -4,7 +4,8 @@ import {
   Parameter,
   OutPort,
   InPort,
-  TimeValue
+  TimeValue,
+  CanConnectResult
 } from "../src/core/internal";
 
 import {SingleEvent} from "../src/share/SingleEvent";
@@ -93,7 +94,7 @@ describe("HierarchicalSingleEvent", function () {
         seTest.seContainer.child.o,
         seTest.logContainer.child.i
       )
-    ).toBe(false);
+    ).toBe(CanConnectResult.NOT_IN_SCOPE);
 
     seTest._start();
   });

--- a/__tests__/InvalidMutations.ts
+++ b/__tests__/InvalidMutations.ts
@@ -40,23 +40,23 @@ class R1 extends Reactor {
       function (this, __in1, __in2, __out1, __out2) {
         test("expect error on creating creating direct feed through", () => {
           expect(() => {
-            this.connect(__in2, __out2);
+            this.connect(__in2.asConnectable(), __out2.asConnectable());
           }).toThrowError("New connection introduces direct feed through.");
         });
         test("expect error when creating connection outside container", () => {
           expect(() => {
-            this.connect(__out2, __in2);
+            this.connect(__out2.asConnectable(), __in2.asConnectable());
           }).toThrowError("New connection is outside of container.");
         });
         const R2 = new R1(this.getReactor());
         test("expect error on mutation creating race condition on an output port", () => {
           expect(() => {
-            this.connect(R2.out1, __out1);
+            this.connect(R2.out1.asConnectable(), __out1.asConnectable());
           }).toThrowError("Destination port is already occupied.");
         });
         test("expect error on spawning and creating loop within a reactor", () => {
           expect(() => {
-            this.connect(R2.out1, R2.in1);
+            this.connect(R2.out1.asConnectable(), R2.in1.asConnectable());
           }).toThrowError("New connection introduces cycle.");
         });
       }

--- a/__tests__/InvalidMutations.ts
+++ b/__tests__/InvalidMutations.ts
@@ -38,11 +38,6 @@ class R1 extends Reactor {
       [this.in1],
       [this.in1, this.in2, this.out1, this.out2],
       function (this, __in1, __in2, __out1, __out2) {
-        test("expect error on creating creating direct feed through", () => {
-          expect(() => {
-            this.connect(__in2.asConnectable(), __out2.asConnectable());
-          }).toThrowError("New connection introduces direct feed through.");
-        });
         test("expect error when creating connection outside container", () => {
           expect(() => {
             this.connect(__out2.asConnectable(), __in2.asConnectable());

--- a/__tests__/SimpleMutation.test.ts
+++ b/__tests__/SimpleMutation.test.ts
@@ -46,7 +46,7 @@ class R2 extends Reactor {
       function (this, __in, __out) {
         test("expect error to be thrown", () => {
           expect(() => {
-            this.connect(__out, __in);
+            this.connect(__out.asConnectable(), __in.asConnectable());
           }).toThrowError("New connection is outside of container.");
         });
       }

--- a/__tests__/SingleEvent.test.ts
+++ b/__tests__/SingleEvent.test.ts
@@ -32,12 +32,8 @@ describe("SingleEvent", function () {
     expect(expect(seTest.singleEvent).toBeInstanceOf(SingleEvent));
     expect(expect(seTest.logger).toBeInstanceOf(Logger));
 
-    expect(function () {
-      seTest.canConnect(seTest.singleEvent.o, seTest.logger.i);
-    }).toThrow(new Error("Destination port is already occupied."));
-    expect(seTest.canConnect(seTest.logger.i, seTest.singleEvent.o)).toBe(
-      false
-    );
+    expect(seTest.canConnect(seTest.singleEvent.o, seTest.logger.i)).toBeTruthy();
+    expect(seTest.canConnect(seTest.logger.i, seTest.singleEvent.o)).toBeTruthy();
 
     seTest._start();
   });

--- a/__tests__/connection.bonus.test.ts
+++ b/__tests__/connection.bonus.test.ts
@@ -1,0 +1,99 @@
+import {App, InPort, OutPort, Reactor} from "../src/core/internal";
+
+// Readers might wonder why this test case exist;
+// This is mainly because in the past, we assume direct feedthrough is forbidden, and will not establish the connection if we try to do so. However, it is possible that such a thing happen without introducing any causality issue.
+describe("Direct feedthrough without causality issue", () => {
+  class BigReactor extends App {
+    public children: SmallReactor;
+
+    constructor() {
+      super(undefined, false, false);
+      this.children = new SmallReactor(this);
+    }
+  }
+
+  class SmallReactor extends Reactor {
+    public inp: InPort<number>;
+    public outp: OutPort<number>;
+
+    constructor(parent: Reactor) {
+      super(parent);
+      this.inp = new InPort(this);
+      this.outp = new OutPort(this);
+      this.addMutation(
+        [this.startup],
+        [this.inp, this.outp],
+        function (this, inp, outp) {
+          it("test", () => {
+            expect(this.getReactor().canConnect(inp, outp)).toBeFalsy();
+          });
+        }
+      );
+    }
+  }
+
+  const root = new BigReactor();
+  root._start();
+});
+
+describe("Causality loop that can't be detected by only checking local graph", () => {
+  class FeedThrougher extends Reactor {
+    public inp = new InPort(this);
+    public outp = new OutPort(this);
+
+    constructor(parent: Reactor) {
+      super(parent);
+      this.addReaction(
+        [this.inp],
+        [this.inp, this.writable(this.outp)],
+        function (this, inp, outp) {
+          // nop troll
+        }
+      );
+    }
+  }
+
+  class Looper extends Reactor {
+    public leftChild = new FeedThrougher(this);
+    public rightChild = new FeedThrougher(this);
+
+    public inp = new InPort(this);
+    public outp = new OutPort(this);
+
+    constructor(parent: Reactor) {
+      super(parent);
+      this.addMutation(
+        [this.startup],
+        [
+          this.inp.asConnectable(),
+          this.outp.asConnectable(),
+          this.leftChild.inp.asConnectable(),
+          this.leftChild.outp.asConnectable(),
+          this.rightChild.inp.asConnectable(),
+          this.rightChild.outp.asConnectable()
+        ],
+        function (this, inp, outp, inp_lc, outp_lc, inp_rc, outp_rc) {
+          this.connect(inp, inp_lc);
+          this.connect(outp_rc, outp);
+        }
+      );
+    }
+  }
+
+  class TestApp extends App {
+    public child = new Looper(this);
+
+    constructor() {
+      super(undefined, undefined, undefined, () => {});
+      this._connect(this.child.outp, this.child.inp);
+      it("Test a connection that would create zero delay loop cannot be made", () => {
+        expect(
+          this.canConnect(this.child.leftChild.outp, this.child.rightChild.inp)
+        ).toBeTruthy();
+      });
+    }
+  }
+
+  const app = new TestApp();
+  app._start();
+});

--- a/__tests__/connection.test.ts
+++ b/__tests__/connection.test.ts
@@ -5,7 +5,8 @@ import {
   OutPort,
   InPort,
   TimeUnit,
-  TimeValue
+  TimeValue,
+  CanConnectResult
 } from "../src/core/internal";
 
 describe("Check canConnect", () => {
@@ -30,19 +31,19 @@ describe("Check canConnect", () => {
 
       it("canConnect success out->in", () => {
         expect(this.canConnect(this.source.out, this.destination.in)).toBe(
-          true
+          CanConnectResult.SUCCESS
         );
       });
 
       it("canConnect success out->out", () => {
         expect(this.canConnect(this.source.out, this.destination.out)).toBe(
-          true
+          CanConnectResult.SUCCESS
         );
       });
 
       it("canConnect failure", () => {
         expect(this.canConnect(this.destination.in, this.source.out)).toBe(
-          false
+          CanConnectResult.NOT_IN_SCOPE
         );
       });
     }

--- a/__tests__/disconnect.test.ts
+++ b/__tests__/disconnect.test.ts
@@ -54,11 +54,11 @@ class R1 extends Reactor {
         const R2 = new R1(this.getReactor());
         test("expect that disconnecting an existing connection will not result in an error being thrown", () => {
           expect(() => {
-            this.connect(R2.out2, R2.in2);
+            this.connect(R2.out2.asConnectable(), R2.in2.asConnectable());
             this.disconnect(R2.out2, R2.in2);
-            this.connect(R2.out2, R2.in2);
+            this.connect(R2.out2.asConnectable(), R2.in2.asConnectable());
             this.disconnect(R2.out2);
-            this.connect(R2.out2, R2.in2);
+            this.connect(R2.out2.asConnectable(), R2.in2.asConnectable());
           }).not.toThrow();
         });
       }

--- a/__tests__/hierarchy.ts
+++ b/__tests__/hierarchy.ts
@@ -1,4 +1,4 @@
-import {Reactor, App, InPort, OutPort} from "../src/core/internal";
+import {Reactor, App, InPort, OutPort, CanConnectResult} from "../src/core/internal";
 
 class InOut extends Reactor {
   a = new InPort<string>(this);
@@ -36,65 +36,57 @@ describe("Container to Contained", () => {
   it("testing canConnect", () => {
     expect(
       app.container.canConnect(app.container.a, app.container.contained.a)
-    ).toBe(true);
+    ).toBe(CanConnectResult.SUCCESS);
     expect(
       app.container.canConnect(app.container.contained.a, app.container.a)
-    ).toBe(false);
+    ).toBe(CanConnectResult.NOT_IN_SCOPE);
     expect(
       app.container.canConnect(
         app.container.a,
         app.container.b
       )
-    ).toBe(true);
+    ).toBe(CanConnectResult.SUCCESS);
     expect(
       app.container.canConnect(
         app.container.contained.a,
         app.container.contained.b
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.canConnect(
         app.container.contained.b,
         app.container.contained.a
       )
-    ).toBe(true);
+    ).toBeFalsy();
 
     expect(
       app.container.canConnect(app.container.a, app.container.contained.b)
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.canConnect(app.container.contained.b, app.container.a)
-    ).toBe(false);
+    ).toBeTruthy();
 
     expect(
       app.container.canConnect(app.container.b, app.container.contained.a)
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.canConnect(app.container.contained.a, app.container.b)
-    ).toBe(false);
+    ).toBeTruthy();
 
     expect(
       app.container.canConnect(app.container.b, app.container.contained.b)
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.canConnect(app.container.contained.b, app.container.b)
-    ).toBe(true);
+    ).toBeFalsy();
 
-    expect(app.container.canConnect(app.container.contained.a, app.foo.a)).toBe(
-      false
-    );
-    expect(app.container.canConnect(app.container.contained.a, app.foo.b)).toBe(
-      false
-    );
-    expect(app.container.canConnect(app.foo.a, app.container.contained.a)).toBe(
-      false
-    );
-    expect(app.container.canConnect(app.foo.a, app.container.contained.a)).toBe(
-      false
-    );
+    expect(app.container.canConnect(app.container.contained.a, app.foo.a)).toBeTruthy();
+    expect(app.container.canConnect(app.container.contained.a, app.foo.b)).toBeTruthy();
+    expect(app.container.canConnect(app.foo.a, app.container.contained.a)).toBeTruthy();
+    expect(app.container.canConnect(app.foo.a, app.container.contained.a)).toBeTruthy();
 
-    expect(app.container.canConnect(app.foo.a, app.container.b)).toBe(false);
-    expect(app.container.canConnect(app.foo.a, app.container.a)).toBe(false);
+    expect(app.container.canConnect(app.foo.a, app.container.b)).toBeTruthy();
+    expect(app.container.canConnect(app.foo.a, app.container.a)).toBeTruthy();
 
     // expect(app.container.contained).toBeDefined();
 
@@ -104,49 +96,49 @@ describe("Container to Contained", () => {
         app.container.contained.containedAgain.a,
         app.container.contained.a
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.b,
         app.container.contained.b
       )
-    ).toBe(true);
+    ).toBeFalsy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.a,
         app.container.a
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.b,
         app.container.b
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.a,
         app.foo.a
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.b,
         app.foo.b
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.a,
         app.foo.a
       )
-    ).toBe(false);
+    ).toBeTruthy();
     expect(
       app.container.contained.canConnect(
         app.container.contained.containedAgain.b,
         app.foo.b
       )
-    ).toBe(false);
+    ).toBeTruthy();
     // }
   });
 });

--- a/__tests__/mutations.test.ts
+++ b/__tests__/mutations.test.ts
@@ -92,7 +92,7 @@ class Computer extends Reactor {
             continue;
           }
           const x = new AddOne(this.getReactor(), id);
-          this.connect(src, x.input);
+          this.connect(src.asConnectable(), x.input.asConnectable());
         }
       }
     });

--- a/src/benchmark/Sieve.ts
+++ b/src/benchmark/Sieve.ts
@@ -1,5 +1,4 @@
 import {
-  type WritablePort,
   Parameter,
   InPort,
   OutPort,
@@ -66,11 +65,12 @@ class Filter extends Reactor {
       [
         this.inp,
         this.writable(this.out),
+        this.out.asConnectable(),
         this.startPrime,
         this.hasChild,
         this.localPrimes
       ],
-      function (this, inp, out, prime, hasChild, localPrimes) {
+      function (this, inp, outW, outC, prime, hasChild, localPrimes) {
         const p = inp.get();
         if (p !== undefined) {
           const seen = localPrimes.get();
@@ -96,14 +96,13 @@ class Filter extends Reactor {
                 // let x = this.create(Filter, [this.getReactor(), p])
                 // console.log("CREATED: " + x._getFullyQualifiedName())
                 // FIXME: weird hack. Maybe just accept writable ports as well?
-                const port = (out as unknown as WritablePort<number>).getPort();
-                this.connect(port, n.inp);
+                this.connect(outC, n.inp.asConnectable());
                 // FIXME: this updates the dependency graph, but it doesn't redo the topological sort
                 // For a pipeline like this one, it is not necessary, but in general it is.
                 // Can we avoid redoing the entire sort?
                 hasChild.set(true);
               } else {
-                out.set(p);
+                outW.set(p);
               }
             }
           }

--- a/src/core/port.ts
+++ b/src/core/port.ts
@@ -7,7 +7,8 @@ import type {
   Absent,
   MultiReadWrite,
   ReadWrite,
-  Variable
+  Variable,
+  Read
 } from "./internal";
 import {Trigger, Log} from "./internal";
 
@@ -59,6 +60,13 @@ export abstract class Port<T> extends Trigger {
   }
 }
 
+export class ConnectablePort<T> implements Read<T> {
+  public get = (): Absent => undefined;
+  public getPort = (): IOPort<T> => this.port;
+
+  constructor(public port: IOPort<T>) {}
+}
+
 /**
  * Abstract class for a writable port. It is intended as a wrapper for a
  * regular port. In addition to a get method, it also has a set method and
@@ -101,6 +109,10 @@ export abstract class IOPort<T> extends Port<T> {
     } else {
       return undefined;
     }
+  }
+
+  public asConnectable(): ConnectablePort<T> {
+    return new ConnectablePort(this);
   }
 
   /**

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -42,7 +42,8 @@ import {
   Startup,
   Shutdown,
   WritableMultiPort,
-  Dummy
+  Dummy,
+  ConnectablePort
 } from "./internal";
 import {v4 as uuidv4} from "uuid";
 import {Bank} from "./bank";
@@ -440,16 +441,31 @@ export abstract class Reactor extends Component {
      * @param src
      * @param dst
      */
+
+    public connect<R, S extends R>(
+      src: ConnectablePort<S>,
+      dst: ConnectablePort<R>
+    ): void;
     public connect<A extends T, R, T, S extends R>(
-      src: CallerPort<A, R> | IOPort<S>,
-      dst: CalleePort<T, S> | IOPort<R>
+      src: CallerPort<A, R>,
+      dst: CalleePort<T, S>
+    ): void;
+    public connect<A extends T, R, T, S extends R>(
+      ...[src, dst]:
+        | [ConnectablePort<S>, ConnectablePort<R>]
+        | [CallerPort<A, R>, CalleePort<T, S>]
     ): void {
       if (src instanceof CallerPort && dst instanceof CalleePort) {
         this.reactor._connectCall(src, dst);
-      } else if (src instanceof IOPort && dst instanceof IOPort) {
-        this.reactor._connect(src, dst);
+      } else if (
+        src instanceof ConnectablePort &&
+        dst instanceof ConnectablePort
+      ) {
+        this.reactor._connect(src.getPort(), dst.getPort());
       } else {
-        // ERROR
+        throw Error(
+          "Logically unreachable code: src and dst type mismatch, Caller(ee) port cannot be connected to IOPort."
+        );
       }
     }
 
@@ -1805,10 +1821,13 @@ interface UtilityFunctions {
 }
 
 export interface MutationSandbox extends ReactionSandbox {
-  connect: <A extends T, R, T, S extends R>(
-    src: CallerPort<A, R> | IOPort<S>,
-    dst: CalleePort<T, S> | IOPort<R>
-  ) => void;
+  connect: {
+    <R, S extends R>(src: ConnectablePort<S>, dst: ConnectablePort<R>): void;
+    <A extends T, R, T, S extends R>(
+      src: CallerPort<A, R>,
+      dst: CalleePort<T, S>
+    ): void;
+  };
 
   disconnect: <R, S extends R>(src: IOPort<S>, dst?: IOPort<R>) => void;
 

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -1169,32 +1169,21 @@ export abstract class Reactor extends Component {
         return CanConnectResult.RT_CONNECTION_OUTSIDE_CONTAINER;
       }
 
-      // Take the local graph and merge in all the causality interfaces
-      // of contained reactors. Then:
-      const graph = new PrecedenceGraph<Port<unknown> | Reaction<Variable[]>>();
-      graph.addAll(this._dependencyGraph);
+      /**
+       * TODO (axmmisaka): The following code is commented for multiple reasons:
+       * The causality interface check is not fully implemented so new checks are failing
+       * Second, direct feedthrough itself would not cause any problem *per se*.
+       * To ensure there is no cycle, the safest way is to check against the global dependency graph.
+       */
 
-      for (const r of this._getOwnReactors()) {
-        graph.addAll(r._getCausalityInterface());
+      let app = this as Reactor;
+      while (app._getContainer() !== app) {
+        app = app._getContainer();
       }
-
-      // Add the new edge.
+      const graph = app._getPrecedenceGraph();
       graph.addEdge(src, dst);
-
-      // 1) check for loops
-      const hasCycle = graph.hasCycle();
-      if (hasCycle) {
+      if (graph.hasCycle()) {
         return CanConnectResult.RT_CYCLE;
-      }
-
-      // 2) check for direct feed through.
-      // FIXME: This doesn't handle while direct feed thorugh cases.
-      if (
-        src instanceof InPort &&
-        dst instanceof OutPort &&
-        dst.getContainer() === src.getContainer()
-      ) {
-        return CanConnectResult.RT_DIRECT_FEED_THROUGH;
       }
 
       return CanConnectResult.SUCCESS;

--- a/src/core/reactor.ts
+++ b/src/core/reactor.ts
@@ -61,6 +61,18 @@ export interface Call<A, R> extends Write<A>, Read<R> {
   invoke: (args: A) => R | undefined;
 }
 
+export enum CanConnectResult {
+  SUCCESS = 0,
+  SELF_LOOP = "Source port and destination port are the same.",
+  DESTINATION_OCCUPIED = "Destination port is already occupied.",
+  DOWNSTREAM_WRITE_CONFLICT = "Write conflict: port is already occupied.",
+  NOT_IN_SCOPE = "Source and destination ports are not in scope.",
+  RT_CONNECTION_OUTSIDE_CONTAINER = "New connection is outside of container.",
+  RT_DIRECT_FEED_THROUGH = "New connection introduces direct feed through.",
+  RT_CYCLE = "New connection introduces cycle.",
+  MUTATION_CAUSALITY_LOOP = "New connection will change the causal effect of the mutation that triggered this connection."
+}
+
 /**
  * Abstract class for a schedulable action. It is intended as a wrapper for a
  * regular action. In addition to a get method, it also has a schedule method
@@ -1092,10 +1104,13 @@ export abstract class Reactor extends Component {
    * @param src The start point of a new connection.
    * @param dst The end point of a new connection.
    */
-  public canConnect<R, S extends R>(src: IOPort<S>, dst: IOPort<R>): boolean {
+  public canConnect<R, S extends R>(
+    src: IOPort<S>,
+    dst: IOPort<R>
+  ): CanConnectResult {
     // Immediate rule out trivial self loops.
     if (src === dst) {
-      throw Error("Source port and destination port are the same.");
+      return CanConnectResult.SELF_LOOP;
     }
 
     // Check the race condition
@@ -1103,7 +1118,7 @@ export abstract class Reactor extends Component {
     //     in addReaction)
     const deps = this._dependencyGraph.getUpstreamNeighbors(dst); // FIXME this will change with multiplex ports
     if (deps !== undefined && deps.size > 0) {
-      throw Error("Destination port is already occupied.");
+      return CanConnectResult.DESTINATION_OCCUPIED;
     }
 
     if (!this._runtime.isRunning()) {
@@ -1115,10 +1130,13 @@ export abstract class Reactor extends Component {
       // Rule out write conflicts.
       //   - (between reactors)
       if (this._dependencyGraph.getDownstreamNeighbors(dst).size > 0) {
-        return false;
+        return CanConnectResult.DOWNSTREAM_WRITE_CONFLICT;
       }
 
-      return this._isInScope(src, dst);
+      if (!this._isInScope(src, dst)) {
+        return CanConnectResult.NOT_IN_SCOPE;
+      }
+      return CanConnectResult.SUCCESS;
     } else {
       // Attempt to make a connection while executing.
       // Check the local dependency graph to figure out whether this change
@@ -1132,7 +1150,7 @@ export abstract class Reactor extends Component {
         src._isContainedBy(this) &&
         dst._isContainedBy(this)
       ) {
-        throw Error("New connection is outside of container.");
+        return CanConnectResult.RT_CONNECTION_OUTSIDE_CONTAINER;
       }
 
       // Take the local graph and merge in all the causality interfaces
@@ -1149,23 +1167,21 @@ export abstract class Reactor extends Component {
 
       // 1) check for loops
       const hasCycle = graph.hasCycle();
+      if (hasCycle) {
+        return CanConnectResult.RT_CYCLE;
+      }
 
       // 2) check for direct feed through.
       // FIXME: This doesn't handle while direct feed thorugh cases.
-      let hasDirectFeedThrough = false;
-      if (src instanceof InPort && dst instanceof OutPort) {
-        hasDirectFeedThrough = dst.getContainer() === src.getContainer();
-      }
-      // Throw error cases
-      if (hasDirectFeedThrough && hasCycle) {
-        throw Error("New connection introduces direct feed through and cycle.");
-      } else if (hasCycle) {
-        throw Error("New connection introduces cycle.");
-      } else if (hasDirectFeedThrough) {
-        throw Error("New connection introduces direct feed through.");
+      if (
+        src instanceof InPort &&
+        dst instanceof OutPort &&
+        dst.getContainer() === src.getContainer()
+      ) {
+        return CanConnectResult.RT_DIRECT_FEED_THROUGH;
       }
 
-      return true;
+      return CanConnectResult.SUCCESS;
     }
   }
 
@@ -1259,11 +1275,14 @@ export abstract class Reactor extends Component {
     if (dst === undefined || dst === null) {
       throw new Error("Cannot connect unspecified destination");
     }
-    if (this.canConnect(src, dst)) {
-      this._uncheckedConnect(src, dst);
-    } else {
-      throw new Error(`ERROR connecting ${src} to ${dst}`);
+    const canConnectResult = this.canConnect(src, dst);
+    // I know, this looks a bit weird. But
+    if (canConnectResult !== CanConnectResult.SUCCESS) {
+      throw new Error(
+        `ERROR connecting ${src} to ${dst}. Reason is ${canConnectResult.valueOf()}`
+      );
     }
+    this._uncheckedConnect(src, dst);
   }
 
   protected _connectMulti<R, S extends R>(
@@ -1317,7 +1336,8 @@ export abstract class Reactor extends Component {
     }
 
     for (let i = 0; i < leftPorts.length && i < rightPorts.length; i++) {
-      if (!this.canConnect(leftPorts[i], rightPorts[i])) {
+      const canConnectResult = this.canConnect(leftPorts[i], rightPorts[i]);
+      if (canConnectResult !== CanConnectResult.SUCCESS) {
         throw new Error(
           `ERROR connecting ${leftPorts[i]} 
                     to ${rightPorts[i]} 


### PR DESCRIPTION
0. `canConnect` doesn't experience situations where throwing Error is required.
1. `canConnect` is solely for testing and should not throw.
2. `connect` and `connectMulti` should throw. Simply return result from `canConnect` and throw in functions that calls them.
3. A mutation referencing a port for connection/disconnection should NOT result in any causality change *per se* between the port and the mutation

- [x] Refactor tests
- [x] Add descriptions for the enum members
- [x] Implement `ConnectablePort`
~~Note: this task ended up being a rather insane one - I told @lhstrh on Friday that I will make some slight restructuring to make it more sane, but it turns out that my attempts are rather futile and I will commit the rough and crazy one I made on Friday. The issue is that `ConnectablePort` must still be able to be a valid `Variable` and cannot be a copy/wrapper that could be passed into `connect`. After all, `connect` taking an `IOPort` is too big to be changed as of now. So my approach is to make a simple wrapper to bypass the causality interface update. I think a more radical solution (such as making `connect` only take `ConnectablePort`, and unwrap/get the `IOPort` inside of it) deserves another branch/PR.~~
- [x] Fix connection bugs (which is why jest is not passing)
    - [x] Do not automatically fail direct feedthrough if it does not create any causality issue 
    - [ ] ~~Do not limit the scope on local check if causality interface has changed~~ Always do global check
- [x] Discuss with @lhstrh if in-mutation casting should be allowed