### PR TITLE
Added `publish` npm script/hook to ensure runtime gets built when referenced as a git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     },
     "scripts": {
         "build": "npx tsc",
+        "install": "npm run build",
         "check-style": "npx prettier --check src",
         "clean": "npx rimraf lib",
         "doc": "typedoc --out docs src/index.ts && touch docs/.nojekyll",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,11 @@
     },
     "scripts": {
         "build": "npx tsc",
-        "install": "npm run build",
         "check-style": "npx prettier --check src",
         "clean": "npx rimraf lib",
         "doc": "typedoc --out docs src/index.ts && touch docs/.nojekyll",
         "format": "npx prettier --write src",
-        "prepublishOnly": "npm run clean && npm run build",
+        "prepare": "npm run clean && npm run build",
         "test": "jest --coverage",
         "lint": "npx eslint './src/**/*'"
     },


### PR DESCRIPTION
Behavior changed because `prepublish` was changed to `prepublishonly` due to prettier suggestion (?), but it's not consistent.
idk why it doesn't work with npm in the past. npm should run `prepublish` as well.

Now we use `prepare`, which will run before `publish` and `install`.


**squash and merge plz**
