### PR TITLE
Remove PTAG and ABS messages

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-remove-absent-messages
+master

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-reactor-ts-remove-ulog
+remove-absent-messages

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1929,7 +1929,7 @@ export class FederatedApp extends App {
     this.sendRTINextEventTag(this.util.getCurrentTag());
 
     if (
-      this.upstreamFedIDs.length == 0 ||
+      this.upstreamFedIDs.length === 0 ||
       this.greatestTimeAdvanceGrant.isSimultaneousWith(this.util.getStartTag())
     ) {
       // PTAG for the start tag is already received, call _next immediately.

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1929,6 +1929,7 @@ export class FederatedApp extends App {
     this.sendRTINextEventTag(this.util.getCurrentTag());
 
     if (
+      this.upstreamFedIDs.length == 0 ||
       this.greatestTimeAdvanceGrant.isSimultaneousWith(this.util.getStartTag())
     ) {
       // PTAG for the start tag is already received, call _next immediately.


### PR DESCRIPTION
This PR aims to align reactor-ts with [PR#2118](https://github.com/lf-lang/lingua-franca/pull/2118) in lingua-franca that removes unnecessary PTAG and ABS messages.