### PR TITLE
Do not report error when receiving DNET signals

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+rti-DNET

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -248,6 +248,18 @@ enum RTIMessageTypes {
   MSG_TYPE_NEIGHBOR_STRUCTURE = 24,
 
   /**
+   * Byte identifying a downstream next event tag (DNET) message sent
+   * from the RTI in centralized coordination.
+   * The next eight bytes will be the timestamp.
+   * The next four bytes will be the microstep.
+   * This signal from the RTI tells the destination federate the latest tag that
+   * the federate can safely skip sending a next event tag (NET) signal.
+   * In other words, the federate doesn't have to send NET signals with tags
+   * earlier than or equal to this tag unless it cannot advance to its next event tag.
+   */
+  MSG_TYPE_DOWNSTREAM_NEXT_EVENT_TAG = 26,
+
+  /**
    * Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS message
    * sent by the RTI to the federate
    * with a payload indicating the UDP port to use for clock synchronization.
@@ -1153,6 +1165,23 @@ class RTIClient extends EventEmitter {
           });
           this.emit("portAbsent", portID, intendedTag);
           bufferIndex += 17;
+          break;
+        }
+        case RTIMessageTypes.MSG_TYPE_DOWNSTREAM_NEXT_EVENT_TAG: {
+          // The next eight bytes are the timestamp.
+          // The next four bytes are the microstep.
+          Log.debug(this, () => {
+            return (
+              "Received an RTI MSG_TYPE_STOP_GRANTED. FIXME: No functionality has " +
+              "been implemented yet for a federate receiving a MSG_TYPE_STOP_GRANTED message " +
+              "from the RTI"
+            );
+          });
+          const tagBuffer = Buffer.alloc(12);
+          assembledData.copy(tagBuffer, 0, bufferIndex + 1, bufferIndex + 13);
+          const tag = Tag.fromBinary(tagBuffer);
+          // this.emit("downstreamNextEventTag", tag);
+          bufferIndex += 13;
           break;
         }
         case RTIMessageTypes.MSG_TYPE_ACK: {

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1170,16 +1170,15 @@ class RTIClient extends EventEmitter {
         case RTIMessageTypes.MSG_TYPE_DOWNSTREAM_NEXT_EVENT_TAG: {
           // The next eight bytes are the timestamp.
           // The next four bytes are the microstep.
-          Log.debug(this, () => {
-            return (
-              "Received an RTI MSG_TYPE_STOP_GRANTED. FIXME: No functionality has " +
-              "been implemented yet for a federate receiving a MSG_TYPE_STOP_GRANTED message " +
-              "from the RTI"
-            );
-          });
           const tagBuffer = Buffer.alloc(12);
           assembledData.copy(tagBuffer, 0, bufferIndex + 1, bufferIndex + 13);
           const tag = Tag.fromBinary(tagBuffer);
+
+          Log.debug(this, () => {
+            return `Downstream next event tag (DNET) received from RTI for ${tag}.
+              FIXME: No functionality has been implemented yet for a federate receiving 
+              a MSG_TYPE_STOP_GRANTED message from the RTI`;
+          });
           // this.emit("downstreamNextEventTag", tag);
           bufferIndex += 13;
           break;

--- a/src/core/federation.ts
+++ b/src/core/federation.ts
@@ -1176,10 +1176,8 @@ class RTIClient extends EventEmitter {
 
           Log.debug(this, () => {
             return `Downstream next event tag (DNET) received from RTI for ${tag}.
-              FIXME: No functionality has been implemented yet for a federate receiving 
-              a MSG_TYPE_STOP_GRANTED message from the RTI`;
+              DNET is not yet supported in TypeScript. Ignored.`;
           });
-          // this.emit("downstreamNextEventTag", tag);
           bufferIndex += 13;
           break;
         }


### PR DESCRIPTION
This PR includes an ad-hoc handling of DNET signals. Federates read the bytes from the socket and do nothing with the information. 